### PR TITLE
feat: add organization support to CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,8 +16,9 @@ import { commandPull } from './commands/pull.js';
 import { commandLink } from './commands/link.js';
 import { commandShare } from './commands/share.js';
 import { commandSetup } from './commands/setup.js';
+import { commandOrg } from './commands/org.js';
 
-const GLOBAL_COMMANDS = ['init', 'setup', 'list', 'show', 'delete', 'status', 'diff', 'refs', 'view', 'login', 'logout', 'push', 'pull', 'link', 'share', 'help'];
+const GLOBAL_COMMANDS = ['init', 'setup', 'list', 'show', 'delete', 'status', 'diff', 'refs', 'view', 'login', 'logout', 'push', 'pull', 'link', 'share', 'org', 'help'];
 
 function printHelp(): void {
   const help = `
@@ -44,10 +45,13 @@ Usage:
 Cloud:
   omm login                         Log in to omm.dev
   omm logout                        Log out
-  omm link [slug]                   Link project to a cloud slug
+  omm link [org/slug]                Link project to a cloud slug
   omm push                          Push .omm/ to cloud
   omm pull                          Pull .omm/ from cloud
   omm share                         Print the shareable URL
+  omm org list                      List your organizations
+  omm org switch <slug>             Set default organization
+  omm org members [slug]            View members (opens web)
 
 Fields: description, diagram, constraint, concern, context, todo, note
 `;
@@ -155,6 +159,10 @@ async function main(): Promise<void> {
 
     case 'share':
       commandShare();
+      return;
+
+    case 'org':
+      await commandOrg(args[1], args[2]);
       return;
 
     default:

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -13,6 +13,10 @@ export function commandLink(input?: string): void {
   if (input && input.includes('/')) {
     // Format: org_slug/project_slug
     const parts = input.split('/');
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+      process.stderr.write("error: format must be 'org_slug/project_slug'\n");
+      process.exit(1);
+    }
     orgSlug = parts[0];
     projectSlug = parts[1];
   } else {

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -2,11 +2,24 @@ import fs from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
 import { ensureOmmForWrite, getOmmDir } from '../lib/store.js';
+import { getDefaultOrg } from '../lib/cloud.js';
 
-export function commandLink(slug?: string): void {
+export function commandLink(input?: string): void {
   ensureOmmForWrite();
 
-  const resolvedSlug = slug || path.basename(process.cwd());
+  let orgSlug: string | undefined;
+  let projectSlug: string;
+
+  if (input && input.includes('/')) {
+    // Format: org_slug/project_slug
+    const parts = input.split('/');
+    orgSlug = parts[0];
+    projectSlug = parts[1];
+  } else {
+    // Just project slug — use default org
+    projectSlug = input || path.basename(process.cwd());
+    orgSlug = getDefaultOrg() ?? undefined;
+  }
 
   const configPath = path.join(getOmmDir(), 'config.yaml');
   let config: Record<string, unknown> = {};
@@ -15,11 +28,17 @@ export function commandLink(slug?: string): void {
     config = (YAML.parse(raw) as Record<string, unknown>) || {};
   }
 
-  config.cloud = {
+  const cloudConfig: Record<string, unknown> = {
     ...(config.cloud as Record<string, unknown> | undefined),
-    project_slug: resolvedSlug,
+    project_slug: projectSlug,
   };
+  if (orgSlug) {
+    cloudConfig.org_slug = orgSlug;
+  }
+  config.cloud = cloudConfig;
 
   fs.writeFileSync(configPath, YAML.stringify(config), 'utf-8');
-  process.stderr.write(`Linked to ${resolvedSlug}. Run 'omm push' to upload.\n`);
+
+  const display = orgSlug ? `${orgSlug}/${projectSlug}` : projectSlug;
+  process.stderr.write(`Linked to ${display}. Run 'omm push' to upload.\n`);
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
 import { execSync } from 'node:child_process';
-import { getApiUrl, saveToken } from '../lib/cloud.js';
+import { getApiUrl, saveToken, saveHandle } from '../lib/cloud.js';
 
 function findOpenPort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -22,7 +22,7 @@ export async function commandLogin(): Promise<void> {
   const port = await findOpenPort();
   const callbackUrl = `http://localhost:${port}/callback`;
 
-  const tokenPromise = new Promise<string>((resolve, reject) => {
+  const tokenPromise = new Promise<{ token: string; handle?: string }>((resolve, reject) => {
     const timeout = setTimeout(() => {
       server.close();
       reject(new Error('Login timed out (60s). Try again.'));
@@ -33,8 +33,8 @@ export async function commandLogin(): Promise<void> {
 
       if (url.pathname === '/callback') {
         const token = url.searchParams.get('token');
+        const handle = url.searchParams.get('handle');
 
-        // Send response page
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(`
           <html><body style="background:#1e1e2e;color:#a6e3a1;font-family:monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
@@ -49,7 +49,7 @@ export async function commandLogin(): Promise<void> {
         server.close();
 
         if (token) {
-          resolve(token);
+          resolve({ token, handle: handle ?? undefined });
         } else {
           reject(new Error('No token received'));
         }
@@ -72,9 +72,12 @@ export async function commandLogin(): Promise<void> {
   process.stderr.write(`Waiting for authentication...\n`);
 
   try {
-    const token = await tokenPromise;
+    const { token, handle } = await tokenPromise;
     saveToken(token);
-    process.stderr.write('Logged in successfully\n');
+    if (handle) {
+      saveHandle(handle);
+    }
+    process.stderr.write(`Logged in successfully${handle ? ` as @${handle}` : ''}\n`);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(`error: ${msg}\n`);

--- a/src/commands/org.ts
+++ b/src/commands/org.ts
@@ -1,0 +1,89 @@
+import { getToken, getHandle, getDefaultOrg, saveDefaultOrg, apiRequest } from '../lib/cloud.js';
+
+export async function commandOrg(subcommand?: string, arg?: string): Promise<void> {
+  const token = getToken();
+  if (!token) {
+    process.stderr.write("error: not logged in. Run 'omm login' first.\n");
+    process.exit(1);
+  }
+
+  switch (subcommand) {
+    case 'list':
+      await orgList();
+      return;
+    case 'switch':
+      orgSwitch(arg);
+      return;
+    case 'members':
+      await orgMembers(arg);
+      return;
+    default:
+      printOrgHelp();
+      return;
+  }
+}
+
+async function orgList(): Promise<void> {
+  const res = await apiRequest('GET', '/api/dashboard');
+  if (!res.ok) {
+    process.stderr.write(`error: failed to fetch orgs (${res.status})\n`);
+    process.exit(1);
+  }
+
+  const data = await res.json() as {
+    orgs?: Array<{ org: { slug: string; name: string; plan: string; role: string } }>
+  };
+
+  const orgs = data.orgs ?? [];
+  const handle = getHandle();
+  const defaultOrg = getDefaultOrg();
+
+  if (orgs.length === 0) {
+    process.stderr.write('No organizations found.\n');
+    return;
+  }
+
+  for (const { org } of orgs) {
+    const isPersonal = org.slug === handle;
+    const isDefault = org.slug === defaultOrg;
+    const marker = isDefault ? '* ' : '  ';
+    const label = isPersonal ? ' (personal)' : '';
+    process.stdout.write(`${marker}${org.slug}${label} [${org.plan}] — ${org.role}\n`);
+  }
+
+  process.stderr.write(`\n* = active org. Use 'omm org switch <slug>' to change.\n`);
+}
+
+function orgSwitch(slug?: string): void {
+  if (!slug) {
+    process.stderr.write("error: omm org switch <slug>\n");
+    process.exit(1);
+  }
+
+  saveDefaultOrg(slug);
+  process.stderr.write(`Switched to org: ${slug}\n`);
+}
+
+async function orgMembers(slug?: string): Promise<void> {
+  const orgSlug = slug ?? getDefaultOrg();
+  if (!orgSlug) {
+    process.stderr.write("error: specify an org or set a default with 'omm org switch <slug>'\n");
+    process.exit(1);
+  }
+
+  // This endpoint requires Supabase session token, not CLI token.
+  // For now, show a message directing to the web UI.
+  process.stderr.write(`View members at: ${process.env.OMM_API_URL || 'https://ohmymermaid.com'}/org/${orgSlug}/settings\n`);
+}
+
+function printOrgHelp(): void {
+  const help = `
+omm org — Manage organizations
+
+Usage:
+  omm org list               List your organizations
+  omm org switch <slug>      Set default organization for push/pull
+  omm org members [slug]     View members (opens web)
+`;
+  process.stdout.write(help.trim() + '\n');
+}

--- a/src/commands/org.ts
+++ b/src/commands/org.ts
@@ -12,7 +12,7 @@ export async function commandOrg(subcommand?: string, arg?: string): Promise<voi
       await orgList();
       return;
     case 'switch':
-      orgSwitch(arg);
+      await orgSwitch(arg);
       return;
     case 'members':
       await orgMembers(arg);
@@ -24,18 +24,18 @@ export async function commandOrg(subcommand?: string, arg?: string): Promise<voi
 }
 
 async function orgList(): Promise<void> {
-  const res = await apiRequest('GET', '/api/dashboard');
+  const res = await apiRequest('GET', '/api/cli/orgs');
   if (!res.ok) {
     process.stderr.write(`error: failed to fetch orgs (${res.status})\n`);
     process.exit(1);
   }
 
   const data = await res.json() as {
-    orgs?: Array<{ org: { slug: string; name: string; plan: string; role: string } }>
+    orgs?: Array<{ slug: string; name: string; plan: string; role: string; is_personal: boolean }>
+    handle?: string
   };
 
   const orgs = data.orgs ?? [];
-  const handle = getHandle();
   const defaultOrg = getDefaultOrg();
 
   if (orgs.length === 0) {
@@ -43,21 +43,31 @@ async function orgList(): Promise<void> {
     return;
   }
 
-  for (const { org } of orgs) {
-    const isPersonal = org.slug === handle;
+  for (const org of orgs) {
     const isDefault = org.slug === defaultOrg;
     const marker = isDefault ? '* ' : '  ';
-    const label = isPersonal ? ' (personal)' : '';
+    const label = org.is_personal ? ' (personal)' : '';
     process.stdout.write(`${marker}${org.slug}${label} [${org.plan}] — ${org.role}\n`);
   }
 
   process.stderr.write(`\n* = active org. Use 'omm org switch <slug>' to change.\n`);
 }
 
-function orgSwitch(slug?: string): void {
+async function orgSwitch(slug?: string): Promise<void> {
   if (!slug) {
     process.stderr.write("error: omm org switch <slug>\n");
     process.exit(1);
+  }
+
+  // Validate the org exists and user has access
+  const res = await apiRequest('GET', '/api/cli/orgs');
+  if (res.ok) {
+    const data = await res.json() as { orgs?: Array<{ slug: string }> };
+    const orgs = data.orgs ?? [];
+    if (!orgs.some(o => o.slug === slug)) {
+      process.stderr.write(`error: org '${slug}' not found or you don't have access.\n`);
+      process.exit(1);
+    }
   }
 
   saveDefaultOrg(slug);

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
-import { getToken, apiRequest } from '../lib/cloud.js';
+import { getToken, getDefaultOrg, apiRequest } from '../lib/cloud.js';
 import { ensureOmmForWrite, getOmmDir } from '../lib/store.js';
 
 export async function commandPull(): Promise<void> {
@@ -24,13 +24,19 @@ export async function commandPull(): Promise<void> {
   const config = YAML.parse(raw) as Record<string, unknown>;
   const cloud = config.cloud as Record<string, unknown> | undefined;
   const slug = cloud?.project_slug as string | undefined;
+  const orgSlug = (cloud?.org_slug as string | undefined) ?? getDefaultOrg() ?? undefined;
 
   if (!slug) {
     process.stderr.write("error: no project slug set. Run 'omm link' first.\n");
     process.exit(1);
   }
 
-  const res = await apiRequest('GET', `/api/pull?slug=${encodeURIComponent(slug)}`);
+  let queryParams = `slug=${encodeURIComponent(slug)}`;
+  if (orgSlug) {
+    queryParams += `&org_slug=${encodeURIComponent(orgSlug)}`;
+  }
+
+  const res = await apiRequest('GET', `/api/pull?${queryParams}`);
 
   if (!res.ok) {
     const text = await res.text();

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import YAML from 'yaml';
-import { getToken, getApiUrl, apiRequest } from '../lib/cloud.js';
+import { getToken, getApiUrl, getDefaultOrg, apiRequest } from '../lib/cloud.js';
 import { ensureOmmForRead, getOmmDir } from '../lib/store.js';
 
 function walkDir(dir: string, base: string): Array<{ path: string; content: string }> {
@@ -51,6 +51,7 @@ export async function commandPush(): Promise<void> {
   const config = YAML.parse(raw) as Record<string, unknown>;
   const cloud = config.cloud as Record<string, unknown> | undefined;
   const slug = cloud?.project_slug as string | undefined;
+  const orgSlug = (cloud?.org_slug as string | undefined) ?? getDefaultOrg() ?? undefined;
 
   if (!slug) {
     process.stderr.write("error: no project slug set. Run 'omm link' first.\n");
@@ -60,9 +61,15 @@ export async function commandPush(): Promise<void> {
   const files = walkDir(ommDir, ommDir);
   const git_commit = getGitCommit();
 
-  process.stderr.write(`Pushing ${files.length} files to ${getApiUrl()}/p/${slug}...\n`);
+  const display = orgSlug ? `${orgSlug}/${slug}` : slug;
+  process.stderr.write(`Pushing ${files.length} files to ${getApiUrl()}/p/${display}...\n`);
 
-  const res = await apiRequest('POST', '/api/push', { slug, files, git_commit });
+  const body: Record<string, unknown> = { slug, files, git_commit };
+  if (orgSlug) {
+    body.org_slug = orgSlug;
+  }
+
+  const res = await apiRequest('POST', '/api/push', body);
 
   if (!res.ok) {
     const text = await res.text();
@@ -70,8 +77,8 @@ export async function commandPush(): Promise<void> {
     process.exit(1);
   }
 
-  const data = await res.json() as { uploaded?: number; url?: string };
-  const uploaded = data.uploaded ?? files.length;
-  const url = data.url ?? `${getApiUrl()}/p/${slug}`;
+  const data = await res.json() as { files_uploaded?: number; url?: string };
+  const uploaded = data.files_uploaded ?? files.length;
+  const url = data.url ?? `${getApiUrl()}/p/${display}`;
   process.stdout.write(`Uploaded ${uploaded} files. View at: ${url}\n`);
 }

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -79,6 +79,6 @@ export async function commandPush(): Promise<void> {
 
   const data = await res.json() as { files_uploaded?: number; url?: string };
   const uploaded = data.files_uploaded ?? files.length;
-  const url = data.url ?? `${getApiUrl()}/p/${display}`;
+  const url = data.url ?? `${getApiUrl()}/dashboard`;
   process.stdout.write(`Uploaded ${uploaded} files. View at: ${url}\n`);
 }

--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
-import { getApiUrl } from '../lib/cloud.js';
+import { getApiUrl, getDefaultOrg } from '../lib/cloud.js';
 import { ensureOmmForRead, getOmmDir } from '../lib/store.js';
 
 export function commandShare(): void {
@@ -17,13 +17,15 @@ export function commandShare(): void {
   const config = YAML.parse(raw) as Record<string, unknown>;
   const cloud = config.cloud as Record<string, unknown> | undefined;
   const slug = cloud?.project_slug as string | undefined;
+  const orgSlug = (cloud?.org_slug as string | undefined) ?? getDefaultOrg() ?? undefined;
 
   if (!slug) {
     process.stderr.write("error: no project slug set. Run 'omm link' first.\n");
     process.exit(1);
   }
 
-  const viewUrl = `${getApiUrl()}/p/${slug}`;
-  process.stdout.write(`Owner view:  ${viewUrl}\n`);
-  process.stdout.write(`Public share: use the Share button on the dashboard (Pro)\n`);
+  const urlPath = orgSlug ? `/p/${orgSlug}/${slug}` : `/p/${slug}`;
+  const viewUrl = `${getApiUrl()}${urlPath}`;
+  process.stdout.write(`View:         ${viewUrl}\n`);
+  process.stdout.write(`Public share: use the Share button on the dashboard (Pro/Team)\n`);
 }

--- a/src/commands/share.ts
+++ b/src/commands/share.ts
@@ -24,8 +24,11 @@ export function commandShare(): void {
     process.exit(1);
   }
 
+  if (!orgSlug) {
+    process.stderr.write("warning: no org set. URL may be incomplete. Run 'omm org switch <slug>' or 'omm link org/project'.\n");
+  }
   const urlPath = orgSlug ? `/p/${orgSlug}/${slug}` : `/p/${slug}`;
   const viewUrl = `${getApiUrl()}${urlPath}`;
   process.stdout.write(`View:         ${viewUrl}\n`);
-  process.stdout.write(`Public share: use the Share button on the dashboard (Pro/Team)\n`);
+  process.stdout.write(`Public share: use the Share button on the dashboard (Personal/Team)\n`);
 }

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -34,7 +34,7 @@ function writeCredentials(creds: Credentials): void {
   if (!fs.existsSync(CREDENTIALS_DIR)) {
     fs.mkdirSync(CREDENTIALS_DIR, { recursive: true });
   }
-  fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify(creds, null, 2), 'utf-8');
+  fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify(creds, null, 2), { encoding: 'utf-8', mode: 0o600 });
 }
 
 export function getToken(): string | null {
@@ -71,9 +71,9 @@ export function saveDefaultOrg(orgSlug: string): void {
 }
 
 export function deleteToken(): void {
-  if (fs.existsSync(CREDENTIALS_FILE)) {
-    fs.unlinkSync(CREDENTIALS_FILE);
-  }
+  const creds = readCredentials();
+  delete creds.token;
+  writeCredentials(creds);
 }
 
 export async function apiRequest(

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -6,6 +6,12 @@ const CREDENTIALS_DIR = path.join(os.homedir(), '.omm');
 const CREDENTIALS_FILE = path.join(CREDENTIALS_DIR, 'credentials.json');
 const DEFAULT_API_URL = 'https://ohmymermaid.com';
 
+interface Credentials {
+  token?: string;
+  handle?: string;
+  default_org?: string;
+}
+
 export function getCredentialsPath(): string {
   return CREDENTIALS_FILE;
 }
@@ -14,22 +20,54 @@ export function getApiUrl(): string {
   return process.env.OMM_API_URL || DEFAULT_API_URL;
 }
 
-export function getToken(): string | null {
-  if (!fs.existsSync(CREDENTIALS_FILE)) return null;
+function readCredentials(): Credentials {
+  if (!fs.existsSync(CREDENTIALS_FILE)) return {};
   try {
     const raw = fs.readFileSync(CREDENTIALS_FILE, 'utf-8');
-    const data = JSON.parse(raw) as { token?: string };
-    return data.token ?? null;
+    return JSON.parse(raw) as Credentials;
   } catch {
-    return null;
+    return {};
   }
 }
 
-export function saveToken(token: string): void {
+function writeCredentials(creds: Credentials): void {
   if (!fs.existsSync(CREDENTIALS_DIR)) {
     fs.mkdirSync(CREDENTIALS_DIR, { recursive: true });
   }
-  fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify({ token }, null, 2), 'utf-8');
+  fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify(creds, null, 2), 'utf-8');
+}
+
+export function getToken(): string | null {
+  return readCredentials().token ?? null;
+}
+
+export function getHandle(): string | null {
+  return readCredentials().handle ?? null;
+}
+
+export function getDefaultOrg(): string | null {
+  return readCredentials().default_org ?? null;
+}
+
+export function saveToken(token: string): void {
+  const creds = readCredentials();
+  creds.token = token;
+  writeCredentials(creds);
+}
+
+export function saveHandle(handle: string): void {
+  const creds = readCredentials();
+  creds.handle = handle;
+  if (!creds.default_org) {
+    creds.default_org = handle;
+  }
+  writeCredentials(creds);
+}
+
+export function saveDefaultOrg(orgSlug: string): void {
+  const creds = readCredentials();
+  creds.default_org = orgSlug;
+  writeCredentials(creds);
 }
 
 export function deleteToken(): void {


### PR DESCRIPTION
## Summary
- Add `org_slug` to push/pull/share commands (reads from config or default org)
- Add `omm org list/switch/members` command
- Support `omm link org/project` format for org-scoped linking
- Save handle and default_org in credentials on login
- Update share URL to `/p/{org}/{project}` format

Pairs with oh-my-mermaid-WEB PR: https://github.com/oh-my-mermaid/oh-my-mermaid-WEB/pull/1

## Test plan
- [ ] `omm login` saves handle and default org
- [ ] `omm link my-org/my-project` sets org_slug in config
- [ ] `omm push` sends org_slug
- [ ] `omm pull` sends org_slug as query param
- [ ] `omm share` shows org-scoped URL
- [ ] `omm org list` lists user's orgs
- [ ] `omm org switch <slug>` updates default org

🤖 Generated with [Claude Code](https://claude.com/claude-code)