### PR TITLE
fix: viewer nested graph overflow, progressive reveal, and deep fitView

### DIFF
--- a/src/server/viewer.html
+++ b/src/server/viewer.html
@@ -116,6 +116,15 @@ body { font-family: var(--font); background: var(--bg); color: var(--text); disp
 .reg-node.selected .nshape { stroke: #818cf8 !important; stroke-width: 2.5px; filter: drop-shadow(0 0 8px rgba(129,140,248,0.6)); }
 /* Overview mode: per-element fade — borders + edges stay visible */
 .grp-inner { transition: opacity .25s; }
+/* Collapsed groups: dim inner content, show center label */
+.grp-node.grp-collapsed > .grp-inner { opacity: 0.15; pointer-events: none; transition: opacity .25s; }
+.grp-node.grp-collapsed > .grp-label-top { opacity: 0; transition: opacity .25s; }
+.grp-node.grp-collapsed > .grp-label-bg { opacity: 0; transition: opacity .25s; }
+/* Focus-exempt override for collapsed groups */
+.grp-node.grp-collapsed.focus-exempt > .grp-inner { opacity: 1 !important; pointer-events: auto !important; }
+.grp-node.grp-collapsed.focus-exempt > .grp-label-top { opacity: 1 !important; }
+.grp-node.grp-collapsed.focus-exempt > .grp-label-bg { opacity: 1 !important; }
+.grp-node.grp-collapsed.focus-exempt > .grp-label-center { display: none !important; }
 #canvas-wrap.zoom-overview .grp-inner { pointer-events: none; }
 #canvas-wrap.zoom-overview .grp-inner > .reg-node { opacity: 0.2; transition: opacity .25s; }
 #canvas-wrap.zoom-overview .grp-inner .edge-path { opacity: 0.4; transition: opacity .25s; }
@@ -127,13 +136,15 @@ body { font-family: var(--font); background: var(--bg); color: var(--text); disp
 .grp-label-center { display: none; }
 #canvas-wrap.zoom-overview .grp-label-top { display: none; }
 #canvas-wrap.zoom-overview .grp-label-center { display: block; }
+/* Hide sub-group direct center labels in zoom-overview (labelOverlay handles these) */
+#canvas-wrap.zoom-overview .grp-inner > .grp-node > .grp-label-center { display: none; }
 /* Sub-group overlay labels (outside grp-inner — unaffected by opacity) */
 .grp-sub-labels { display: none; pointer-events: none; }
 .grp-sub-labels text { opacity: 0.45; }
 /* Depth-aware labels: expanded groups hide center, show top-left */
 .grp-node.grp-expanded > .grp-label-center { display: none; }
-/* Non-expanded: show center label over top label */
-.grp-node:not(.grp-expanded) > .grp-label-center { display: block; opacity: 0.7; }
+/* Center label only visible when collapsed (not merely non-expanded) */
+.grp-node.grp-collapsed:not(.grp-expanded) > .grp-label-center { display: block; opacity: 0.85; }
 /* Top-level expanded: hide center */
 [data-cls].grp-expanded > .grp-label-center { display: none; }
 #canvas-wrap.zoom-overview .grp-sub-labels { display: block; }
@@ -409,7 +420,7 @@ function renderGroup(cls, classesData, allClasses, level, seen = new Set()) {
       const sub = renderGroup(refCls, classesData, allClasses, level+1, seen);
       if (sub) {
         // Scale down to fit max box. At small scales, edge overflow becomes negligible.
-        const MAX_W = 240, MAX_H = 160, PAD = 12;
+        const MAX_W = 320, MAX_H = 220, PAD = 12;
         const fs = Math.min((MAX_W - PAD*2) / sub.W, (MAX_H - PAD*2) / sub.H, 1);
         subGroups[n.id] = { cls: refCls, ...sub, fitScale: fs };
         nodeDims[n.id] = { width: sub.W * fs + PAD * 2, height: sub.H * fs + PAD * 2 };
@@ -562,7 +573,9 @@ function renderGroup(cls, classesData, allClasses, level, seen = new Set()) {
       const fs = sg.fitScale;
       const PAD = 12;
       const boxW = sg.W * fs + PAD * 2, boxH = sg.H * fs + PAD * 2;
-      svg += `<g class="grp-node" onclick="event.stopPropagation();window.__openSb('${safeId}')" data-cls="${safeId}" data-depth="${level+1}" transform="translate(${nx},${ny})">`;
+      const clipId = `${uid}clip_${n.id}`;
+      svg += `<defs><clipPath id="${clipId}"><rect x="-2" y="-16" width="${r1(boxW+4)}" height="${r1(boxH+18)}" rx="6"/></clipPath></defs>`;
+      svg += `<g class="grp-node" clip-path="url(#${clipId})" onclick="event.stopPropagation();window.__openSb('${safeId}')" data-cls="${safeId}" data-depth="${level+1}" transform="translate(${nx},${ny})">`;
       svg += `<rect class="grp-border" width="${r1(boxW)}" height="${r1(boxH)}" rx="5"
         fill="${th.subFill}" stroke="${refSubStroke}" stroke-width="2"/>`;
       const _slW = tw(fmtLabel(sg.cls), '600 9px "Plus Jakarta Sans",Inter,system-ui') + 12;
@@ -570,6 +583,8 @@ function renderGroup(cls, classesData, allClasses, level, seen = new Set()) {
       svg += `<text class="grp-label-top" x="10" y="2" font-family="&quot;Plus Jakarta Sans&quot;,Inter,system-ui" font-size="9" font-weight="600"
         fill="${th.subLabelFill}" letter-spacing="0.05em">${esc(fmtLabel(sg.cls))}</text>`;
       svg += `<g class="grp-inner" transform="translate(${r1(PAD)},${r1(PAD)}) scale(${r1(fs)})">${sg.svgContent}</g>`;
+      svg += `<text class="grp-label-center" x="${r1(boxW/2)}" y="${r1(boxH/2)}" text-anchor="middle" dominant-baseline="central"
+        font-family="&quot;Plus Jakarta Sans&quot;,Inter,system-ui" font-size="9" font-weight="600" fill="${th.grpLabelCenterFill}" letter-spacing="0.05em">${esc(fmtLabel(sg.cls))}</text>`;
       svg += `</g>`;
       labelOverlay += `<text class="grp-label-center" x="${r1(nx + boxW/2)}" y="${r1(ny + boxH/2)}" text-anchor="middle" dominant-baseline="central"
         font-family="&quot;Plus Jakarta Sans&quot;,Inter,system-ui" font-size="9" font-weight="600" fill="${th.grpLabelCenterFill}" letter-spacing="0.05em">${esc(fmtLabel(sg.cls))}</text>`;
@@ -694,12 +709,12 @@ const navList    = document.getElementById('nav-list');
 let vpX=0, vpY=0, vpScale=0.7;
 let classes=[], classesData={}, refsData={};
 let selectedCls=null, svgW=0, svgH=0;
-let maxDepth = 2;  // dynamically updated based on zoom
+const maxDepth = 6;  // always render all depths; visibility controlled per-group by CSS
 
 const api = p => fetch(p).then(r=>r.json()).catch(()=>({}));
 
 // ── transform ──────────────────────────────────────────────
-const MIN_SCALE = 0.02, MAX_SCALE = 8;
+const MIN_SCALE = 0.02, MAX_SCALE = 30;
 
 function applyTransform() {
   canvasEl.style.transform=`translate(${vpX}px,${vpY}px) scale(${vpScale})`;
@@ -742,22 +757,20 @@ function applyTransform() {
     if (!border) return;
     const rect = border.getBoundingClientRect();
     const depth = parseInt(el.getAttribute('data-depth') || '0', 10);
+
+    // Collapse: hide inner content when group is too small on screen (progressive reveal)
+    const collapseThreshold = vpW * 0.275;  // 27.5% of canvas viewport width
+    const collapsed = rect.width < collapseThreshold;
+    el.classList.toggle('grp-collapsed', collapsed);
+
+    // Expansion: label switching (existing logic)
     // Root=50%, depth1=65%, depth2=80% of viewport width to expand
     const threshold = 0.5 + depth * 0.15;
     const expanded = rect.width >= vpW * threshold;
     el.classList.toggle('grp-expanded', expanded);
   });
 
-  // Depth-based re-render (debounced)
-  // Depth scales with zoom — no hard cap
-  const neededDepth = vpScale >= 3.0 ? 6 : vpScale >= 1.5 ? 5 : vpScale >= 0.9 ? 4 : vpScale >= 0.55 ? 3 : 2;
-  if (neededDepth !== maxDepth) {
-    maxDepth = neededDepth;
-    if (_depthTimer) clearTimeout(_depthTimer);
-    _depthTimer = setTimeout(rebuildCanvas, 180);
-  }
 }
-let _depthTimer = null;
 
 function zoomTo(newScale, originX, originY) {
   const s = Math.max(MIN_SCALE, Math.min(MAX_SCALE, newScale));
@@ -833,7 +846,7 @@ function focusGroup(cls) {
   const availH = canvasWrap.clientHeight - 60;
 
   // Target scale to fit element with padding
-  const targetScale = Math.min(2.5, Math.max(0.15, Math.min(availW / svgW, availH / svgH) * 0.85));
+  const targetScale = Math.min(MAX_SCALE, Math.max(0.15, Math.min(availW / svgW, availH / svgH) * 0.85));
 
   // Center in available viewport
   const centerX = (canvasWrap.clientWidth - sbW) / 2;


### PR DESCRIPTION
## Summary
- **Nested graph overflow**: Added `<clipPath>` to sub-group containers so nested SVG content no longer spills outside parent boundaries
- **Progressive reveal**: Replaced global `maxDepth` re-render with per-group CSS-based visibility (collapsed when < 27.5% of viewport width), enabling smooth viewport-aware progressive disclosure
- **Deep fitView**: Increased `MAX_SCALE` to 30 and removed `targetScale` cap so deeply nested nodes (3+ depth) fit correctly when selected

## Test plan
- [ ] `omm view` — verify nested graphs are clipped within parent borders
- [ ] Zoom in/out — verify groups reveal progressively per viewport area, not all at once
- [ ] Click deep nodes in nav sidebar — verify fitView zooms correctly to fill ~85% of viewport
- [ ] Verify zoom-overview mode (very zoomed out) still shows center labels correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)