### PR TITLE
fix: reject unsafe cloud pull paths

### DIFF
--- a/src/__tests__/cloud-paths.test.ts
+++ b/src/__tests__/cloud-paths.test.ts
@@ -1,0 +1,21 @@
+import path from 'node:path';
+import os from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { resolvePullDestination } from '../lib/cloud-paths.js';
+
+describe('resolvePullDestination', () => {
+  const ommDir = path.join(os.tmpdir(), 'omm-path-test', '.omm');
+
+  it('allows safe paths inside the .omm directory', () => {
+    expect(resolvePullDestination(ommDir, 'config.yaml')).toBe(path.join(ommDir, 'config.yaml'));
+    expect(resolvePullDestination(ommDir, 'service/description.md')).toBe(
+      path.join(ommDir, 'service', 'description.md'),
+    );
+  });
+
+  it('rejects paths that escape the .omm directory', () => {
+    expect(() => resolvePullDestination(ommDir, '../secrets.txt')).toThrow(/unsafe file path/i);
+    expect(() => resolvePullDestination(ommDir, '/tmp/evil')).toThrow(/unsafe file path/i);
+    expect(() => resolvePullDestination(ommDir, 'service/../../evil')).toThrow(/unsafe file path/i);
+  });
+});

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import YAML from 'yaml';
 import { getToken, getDefaultOrg, apiRequest } from '../lib/cloud.js';
 import { ensureOmmForWrite, getOmmDir } from '../lib/store.js';
+import { resolvePullDestination } from '../lib/cloud-paths.js';
 
 export async function commandPull(): Promise<void> {
   ensureOmmForWrite();
@@ -48,7 +49,7 @@ export async function commandPull(): Promise<void> {
   const files = data.files ?? [];
 
   for (const file of files) {
-    const dest = path.join(ommDir, file.path);
+    const dest = resolvePullDestination(ommDir, file.path);
     fs.mkdirSync(path.dirname(dest), { recursive: true });
     fs.writeFileSync(dest, file.content, 'utf-8');
   }

--- a/src/lib/cloud-paths.ts
+++ b/src/lib/cloud-paths.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+
+export function resolvePullDestination(ommDir: string, filePath: string): string {
+  if (!filePath) {
+    throw new Error('Unsafe file path received from cloud');
+  }
+
+  const normalized = path.posix.normalize(filePath.replace(/\\/g, '/'));
+  if (!normalized || normalized === '.' || normalized.startsWith('../') || normalized.includes('/../')) {
+    throw new Error(`Unsafe file path received from cloud: ${filePath}`);
+  }
+  if (path.posix.isAbsolute(normalized)) {
+    throw new Error(`Unsafe file path received from cloud: ${filePath}`);
+  }
+
+  const destination = path.resolve(ommDir, normalized);
+  const root = path.resolve(ommDir) + path.sep;
+  if (destination !== path.resolve(ommDir, 'config.yaml') && !destination.startsWith(root)) {
+    throw new Error(`Unsafe file path received from cloud: ${filePath}`);
+  }
+
+  return destination;
+}


### PR DESCRIPTION
## Summary
- add a dedicated pull destination resolver that rejects traversal and absolute paths from cloud bundles
- use the resolver in `omm pull` before writing files to disk
- cover the new path safety contract with regression tests

## Test Plan
- npm test
- npm run build
