### PR TITLE
fix: version-aware plugin setup for Claude Code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "oh-my-mermaid",
       "description": "Turn complex codebases into clear, navigable architecture diagrams with Mermaid",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "source": "./",
       "category": "development",
       "homepage": "https://github.com/oh-my-mermaid/oh-my-mermaid"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-mermaid",
   "description": "Turn complex codebases into clear, navigable architecture diagrams",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "author": {
     "name": "oh-my-mermaid"
   },

--- a/.github/workflows/check-version-sync.yml
+++ b/.github/workflows/check-version-sync.yml
@@ -1,0 +1,35 @@
+name: Check version sync
+
+on:
+  pull_request:
+    paths: [package.json]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify manifests match package.json version
+        run: |
+          PKG=$(node -p "require('./package.json').version")
+          PLUGIN=$(node -p "require('./.claude-plugin/plugin.json').version")
+          MARKET=$(node -p "require('./.claude-plugin/marketplace.json').plugins[0].version")
+
+          FAIL=0
+          if [ "$PKG" != "$PLUGIN" ]; then
+            echo "::error::plugin.json version ($PLUGIN) != package.json ($PKG)"
+            FAIL=1
+          fi
+          if [ "$PKG" != "$MARKET" ]; then
+            echo "::error::marketplace.json version ($MARKET) != package.json ($PKG)"
+            FAIL=1
+          fi
+
+          if [ "$FAIL" = "1" ]; then
+            echo ""
+            echo "Run: npm run sync-version"
+            exit 1
+          fi
+
+          echo "All versions in sync: $PKG ✓"

--- a/.github/workflows/check-version-sync.yml
+++ b/.github/workflows/check-version-sync.yml
@@ -2,34 +2,22 @@ name: Check version sync
 
 on:
   pull_request:
-    paths: [package.json]
+    paths:
+      - package.json
+      - package-lock.json
+      - .claude-plugin/plugin.json
+      - .claude-plugin/marketplace.json
+      - scripts/sync-version.js
+      - scripts/check-version-sync.js
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Verify manifests match package.json version
-        run: |
-          PKG=$(node -p "require('./package.json').version")
-          PLUGIN=$(node -p "require('./.claude-plugin/plugin.json').version")
-          MARKET=$(node -p "require('./.claude-plugin/marketplace.json').plugins[0].version")
-
-          FAIL=0
-          if [ "$PKG" != "$PLUGIN" ]; then
-            echo "::error::plugin.json version ($PLUGIN) != package.json ($PKG)"
-            FAIL=1
-          fi
-          if [ "$PKG" != "$MARKET" ]; then
-            echo "::error::marketplace.json version ($MARKET) != package.json ($PKG)"
-            FAIL=1
-          fi
-
-          if [ "$FAIL" = "1" ]; then
-            echo ""
-            echo "Run: npm run sync-version"
-            exit 1
-          fi
-
-          echo "All versions in sync: $PKG ✓"
+        run: npm run check-version-sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,63 @@
 name: Release to npm
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+    paths: [package.json]
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if version changed
+        id: version
+        run: |
+          NEW=$(node -p "require('./package.json').version")
+          OLD=$(git show HEAD~1:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version")
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "old=$OLD" >> "$GITHUB_OUTPUT"
+          if [ "$NEW" != "$OLD" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if version unchanged
+        if: steps.version.outputs.changed != 'true'
+        run: echo "Version unchanged (${{ steps.version.outputs.old }}), skipping release."
 
       - uses: actions/setup-node@v4
+        if: steps.version.outputs.changed == 'true'
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
-      - run: npm ci
-
-      - run: npm run build
-
-      - run: npm run sync-version
-
-      - name: Verify version matches release tag
+      - name: Install, build, sync
+        if: steps.version.outputs.changed == 'true'
         run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "Version mismatch: package.json=$PKG_VERSION, tag=$TAG_VERSION"
-            exit 1
-          fi
+          npm ci
+          npm run build
+          npm run sync-version
 
-      - run: npm publish --provenance --access public
+      - name: Create git tag and GitHub release
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ steps.version.outputs.new }}"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          gh release create "$VERSION" --generate-notes --title "$VERSION"
+
+      - name: Publish to npm
+        if: steps.version.outputs.changed == 'true'
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths: [package.json]
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -15,6 +19,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
 
       - name: Check if version changed
         id: version
@@ -33,44 +42,60 @@ jobs:
         if: steps.version.outputs.changed != 'true'
         run: echo "Version unchanged (${{ steps.version.outputs.old }}), skipping release."
 
-      - uses: actions/setup-node@v4
-        if: steps.version.outputs.changed == 'true'
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-
-      - name: Install, build, sync
+      - name: Install, test, build, sync
         if: steps.version.outputs.changed == 'true'
         run: |
           npm ci
+          npm test
           npm run build
           npm run sync-version
+          npm run check-version-sync
+          git diff --exit-code -- .claude-plugin/plugin.json .claude-plugin/marketplace.json package-lock.json
 
-      - name: Commit-back synced manifests
+      - name: Detect existing release artifacts
         if: steps.version.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
-          if git diff --cached --quiet; then
-            echo "Manifests already in sync."
-          else
-            git commit -m "chore: sync plugin manifests to v${{ steps.version.outputs.new }}"
-            git push
-          fi
-
-      - name: Create git tag and GitHub release
-        if: steps.version.outputs.changed == 'true'
+        id: release_state
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="v${{ steps.version.outputs.new }}"
-          git tag "$VERSION"
-          git push origin "$VERSION"
-          gh release create "$VERSION" --generate-notes --title "$VERSION"
+          VERSION="${{ steps.version.outputs.new }}"
+          TAG="v$VERSION"
+
+          if npm view "oh-my-mermaid@$VERSION" version >/dev/null 2>&1; then
+            echo "npm_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Publish to npm
-        if: steps.version.outputs.changed == 'true'
+        if: steps.version.outputs.changed == 'true' && steps.release_state.outputs.npm_published != 'true'
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create git tag
+        if: steps.version.outputs.changed == 'true' && steps.release_state.outputs.tag_exists != 'true'
+        run: |
+          TAG="v${{ steps.version.outputs.new }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Create GitHub release
+        if: steps.version.outputs.changed == 'true' && steps.release_state.outputs.release_exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.version.outputs.new }}"
+          gh release create "$TAG" --generate-notes --title "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,19 @@ jobs:
           npm run build
           npm run sync-version
 
+      - name: Commit-back synced manifests
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+          if git diff --cached --quiet; then
+            echo "Manifests already in sync."
+          else
+            git commit -m "chore: sync plugin manifests to v${{ steps.version.outputs.new }}"
+            git push
+          fi
+
       - name: Create git tag and GitHub release
         if: steps.version.outputs.changed == 'true'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm run sync-version
+
+      - name: Verify version matches release tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: package.json=$PKG_VERSION, tag=$TAG_VERSION"
+            exit 1
+          fi
+
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
 .omc/
+.cursor-plugin/
 *.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-mermaid",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-mermaid",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
+    "check-version-sync": "node scripts/check-version-sync.js",
     "sync-version": "node scripts/sync-version.js",
     "prepublishOnly": "npm run build && npm run sync-version"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "sync-version": "node scripts/sync-version.js",
+    "preversion": "npm run build && npm test",
+    "version": "npm run sync-version && git add -A",
+    "postversion": "git push && git push --tags",
     "prepublishOnly": "npm run build && npm run sync-version"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "sync-version": "node scripts/sync-version.js",
-    "preversion": "npm run build && npm test",
-    "version": "npm run sync-version && git add -A",
-    "postversion": "git push && git push --tags",
     "prepublishOnly": "npm run build && npm run sync-version"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-mermaid",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "description": "Architecture mirror for vibe coding — CLI + Claude Code skills",
   "type": "module",
   "bin": {

--- a/scripts/check-version-sync.js
+++ b/scripts/check-version-sync.js
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function readJson(rootDir, relativePath) {
+  const filePath = path.join(rootDir, relativePath);
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+export function collectVersionInfo(rootDir = process.cwd()) {
+  const pkg = readJson(rootDir, 'package.json');
+  const plugin = readJson(rootDir, '.claude-plugin/plugin.json');
+  const marketplace = readJson(rootDir, '.claude-plugin/marketplace.json');
+  const lockfile = readJson(rootDir, 'package-lock.json');
+
+  return {
+    packageVersion: pkg.version,
+    pluginVersion: plugin.version,
+    marketplaceVersion: marketplace.plugins?.[0]?.version ?? null,
+    lockfileVersion: lockfile.version,
+    lockfileRootVersion: lockfile.packages?.['']?.version ?? null,
+  };
+}
+
+export function getVersionMismatchMessages(versions) {
+  const mismatches = [];
+  const {
+    packageVersion,
+    pluginVersion,
+    marketplaceVersion,
+    lockfileVersion,
+    lockfileRootVersion,
+  } = versions;
+
+  if (packageVersion !== pluginVersion) {
+    mismatches.push(`plugin.json version (${pluginVersion}) != package.json (${packageVersion})`);
+  }
+  if (packageVersion !== marketplaceVersion) {
+    mismatches.push(`marketplace.json version (${marketplaceVersion}) != package.json (${packageVersion})`);
+  }
+  if (packageVersion !== lockfileVersion) {
+    mismatches.push(`package-lock.json version (${lockfileVersion}) != package.json (${packageVersion})`);
+  }
+  if (packageVersion !== lockfileRootVersion) {
+    mismatches.push(
+      `package-lock.json packages[""] version (${lockfileRootVersion}) != package.json (${packageVersion})`,
+    );
+  }
+
+  return mismatches;
+}
+
+export function runVersionSyncCheck(rootDir = process.cwd()) {
+  const versions = collectVersionInfo(rootDir);
+  const mismatches = getVersionMismatchMessages(versions);
+
+  if (mismatches.length > 0) {
+    for (const mismatch of mismatches) {
+      process.stderr.write(`::error::${mismatch}\n`);
+    }
+    process.stderr.write('\nRun: npm version <patch|minor|major> && npm run sync-version\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(`All versions in sync: ${versions.packageVersion} ✓\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runVersionSyncCheck();
+}

--- a/src/__tests__/cursor.test.ts
+++ b/src/__tests__/cursor.test.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getPackageVersion = vi.fn();
+
+vi.mock('../lib/platforms/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/platforms/utils.js')>('../lib/platforms/utils.js');
+  return {
+    ...actual,
+    getPackageVersion,
+  };
+});
+
+describe('cursor platform version-aware setup detection', () => {
+  const originalCwd = process.cwd();
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omm-cursor-'));
+    process.chdir(tmpDir);
+    getPackageVersion.mockReset();
+    getPackageVersion.mockReturnValue('0.1.5');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns false when the cursor plugin manifest is missing', async () => {
+    const { cursor } = await import('../lib/platforms/cursor.js');
+
+    expect(cursor.isSetup()).toBe(false);
+  });
+
+  it('returns false when the installed cursor plugin manifest version is stale', async () => {
+    fs.mkdirSync(path.join(tmpDir, '.cursor-plugin'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.cursor-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'oh-my-mermaid', version: '0.1.4' }, null, 2) + '\n',
+    );
+
+    const { cursor } = await import('../lib/platforms/cursor.js');
+
+    expect(cursor.isSetup()).toBe(false);
+  });
+
+  it('returns true when the installed cursor plugin manifest matches the current package version', async () => {
+    fs.mkdirSync(path.join(tmpDir, '.cursor-plugin'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.cursor-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'oh-my-mermaid', version: '0.1.5' }, null, 2) + '\n',
+    );
+
+    const { cursor } = await import('../lib/platforms/cursor.js');
+
+    expect(cursor.isSetup()).toBe(true);
+  });
+});

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execSync = vi.fn();
+const execFileSync = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFileSync,
+  execSync,
+}));
+
+describe('commandUpdate', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execSync.mockReset();
+    execFileSync.mockReset();
+  });
+
+  it('re-runs setup through a fresh omm subprocess after npm update succeeds', async () => {
+    execSync.mockReturnValue('updated');
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const { commandUpdate } = await import('../commands/update.js');
+
+    await commandUpdate();
+
+    expect(execSync).toHaveBeenCalledWith('npm update -g oh-my-mermaid 2>&1', {
+      encoding: 'utf-8',
+    });
+    expect(execFileSync).toHaveBeenCalledWith('omm', ['setup'], { stdio: 'inherit' });
+    stderrWrite.mockRestore();
+  });
+
+  it('fails when the fresh setup subprocess fails', async () => {
+    execSync.mockReturnValue('updated');
+    execFileSync.mockImplementation(() => {
+      throw new Error('setup failed');
+    });
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const { commandUpdate } = await import('../commands/update.js');
+
+    await expect(commandUpdate()).rejects.toThrow('setup failed');
+
+    stderrWrite.mockRestore();
+  });
+});

--- a/src/__tests__/version-sync.test.ts
+++ b/src/__tests__/version-sync.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { collectVersionInfo, getVersionMismatchMessages } from '../../scripts/check-version-sync.js';
+
+let tmpDir: string | null = null;
+
+afterEach(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = null;
+  }
+});
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + '\n');
+}
+
+function createVersionFixture(version: string, overrides?: {
+  pluginVersion?: string;
+  marketplaceVersion?: string;
+  lockfileVersion?: string;
+  rootPackageVersion?: string;
+}): string {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omm-version-sync-'));
+
+  writeJson(path.join(tmpDir, 'package.json'), { name: 'oh-my-mermaid', version });
+  writeJson(path.join(tmpDir, '.claude-plugin', 'plugin.json'), {
+    name: 'oh-my-mermaid',
+    version: overrides?.pluginVersion ?? version,
+  });
+  writeJson(path.join(tmpDir, '.claude-plugin', 'marketplace.json'), {
+    plugins: [{ name: 'oh-my-mermaid', version: overrides?.marketplaceVersion ?? version }],
+  });
+  writeJson(path.join(tmpDir, 'package-lock.json'), {
+    name: 'oh-my-mermaid',
+    version: overrides?.lockfileVersion ?? version,
+    packages: {
+      '': {
+        name: 'oh-my-mermaid',
+        version: overrides?.rootPackageVersion ?? overrides?.lockfileVersion ?? version,
+      },
+    },
+  });
+
+  return tmpDir;
+}
+
+describe('check-version-sync helpers', () => {
+  it('accepts matching package, plugin, marketplace, and lockfile versions', () => {
+    const fixture = createVersionFixture('1.2.3');
+    const versions = collectVersionInfo(fixture);
+
+    expect(versions).toEqual({
+      packageVersion: '1.2.3',
+      pluginVersion: '1.2.3',
+      marketplaceVersion: '1.2.3',
+      lockfileVersion: '1.2.3',
+      lockfileRootVersion: '1.2.3',
+    });
+    expect(getVersionMismatchMessages(versions)).toEqual([]);
+  });
+
+  it('reports all mismatched versions, including a stale package-lock root package version', () => {
+    const fixture = createVersionFixture('1.2.3', {
+      pluginVersion: '1.2.4',
+      marketplaceVersion: '1.2.5',
+      lockfileVersion: '1.2.2',
+      rootPackageVersion: '1.2.1',
+    });
+
+    const versions = collectVersionInfo(fixture);
+
+    expect(getVersionMismatchMessages(versions)).toEqual([
+      'plugin.json version (1.2.4) != package.json (1.2.3)',
+      'marketplace.json version (1.2.5) != package.json (1.2.3)',
+      'package-lock.json version (1.2.2) != package.json (1.2.3)',
+      'package-lock.json packages[\"\"] version (1.2.1) != package.json (1.2.3)',
+    ]);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,9 +16,10 @@ import { commandPull } from './commands/pull.js';
 import { commandLink } from './commands/link.js';
 import { commandShare } from './commands/share.js';
 import { commandSetup } from './commands/setup.js';
+import { commandUpdate } from './commands/update.js';
 import { commandOrg } from './commands/org.js';
 
-const GLOBAL_COMMANDS = ['init', 'setup', 'list', 'show', 'delete', 'status', 'diff', 'refs', 'view', 'login', 'logout', 'push', 'pull', 'link', 'share', 'org', 'help'];
+const GLOBAL_COMMANDS = ['init', 'setup', 'update', 'list', 'show', 'delete', 'status', 'diff', 'refs', 'view', 'login', 'logout', 'push', 'pull', 'link', 'share', 'org', 'help'];
 
 function printHelp(): void {
   const help = `
@@ -29,6 +30,7 @@ Usage:
   omm setup [platform]              Register skills with AI coding tools
   omm setup --list                  Show detected platforms
   omm setup --teardown              Unregister from all platforms
+  omm update                        Update CLI + plugins to latest version
   omm list                          List all classes
   omm show <class>                  Show all fields for a class
   omm delete <class>                Delete a class
@@ -75,6 +77,10 @@ async function main(): Promise<void> {
 
     case 'setup':
       await commandSetup(args.slice(1));
+      return;
+
+    case 'update':
+      await commandUpdate();
       return;
 
     case 'list':

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,20 @@
+import { execSync } from 'node:child_process';
+import { commandSetup } from './setup.js';
+
+export async function commandUpdate(): Promise<void> {
+  // Step 1: Update npm package
+  process.stderr.write('Updating oh-my-mermaid CLI...\n');
+  try {
+    const out = execSync('npm update -g oh-my-mermaid 2>&1', { encoding: 'utf-8' }).trim();
+    if (out) process.stderr.write(`  ${out}\n`);
+    process.stderr.write('  CLI updated.\n');
+  } catch (err: any) {
+    process.stderr.write(`  npm update failed: ${err.message}\n`);
+    process.stderr.write('  Try manually: npm update -g oh-my-mermaid\n');
+    return;
+  }
+
+  // Step 2: Re-run setup to update plugins
+  process.stderr.write('\nUpdating platform plugins...\n');
+  await commandSetup([]);
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,5 +1,4 @@
-import { execSync } from 'node:child_process';
-import { commandSetup } from './setup.js';
+import { execFileSync, execSync } from 'node:child_process';
 
 export async function commandUpdate(): Promise<void> {
   // Step 1: Update npm package
@@ -14,7 +13,12 @@ export async function commandUpdate(): Promise<void> {
     return;
   }
 
-  // Step 2: Re-run setup to update plugins
+  // Step 2: Re-run setup through the freshly installed CLI
   process.stderr.write('\nUpdating platform plugins...\n');
-  await commandSetup([]);
+  try {
+    execFileSync('omm', ['setup'], { stdio: 'inherit' });
+  } catch (err: any) {
+    process.stderr.write('  Updated the npm package, but failed to re-run `omm setup`.\n');
+    throw err;
+  }
 }

--- a/src/lib/platforms/claude.ts
+++ b/src/lib/platforms/claude.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import type { Platform } from './types.js';
+import { getPackageVersion } from './utils.js';
 
 function run(cmd: string): { ok: boolean; out: string } {
   try {
@@ -8,6 +9,24 @@ function run(cmd: string): { ok: boolean; out: string } {
   } catch {
     return { ok: false, out: '' };
   }
+}
+
+/** Extract installed plugin version from `claude plugin list` output */
+function getInstalledVersion(): string | null {
+  const { ok, out } = run('claude plugin list 2>&1');
+  if (!ok) return null;
+  // Match "Version: X.Y.Z" line after oh-my-mermaid
+  const lines = out.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes('oh-my-mermaid') && !lines[i].includes('oh-my-claudecode')) {
+      // Look for Version line in next few lines
+      for (let j = i + 1; j < Math.min(i + 5, lines.length); j++) {
+        const m = lines[j].match(/Version:\s*([\d.]+)/);
+        if (m) return m[1];
+      }
+    }
+  }
+  return null;
 }
 
 export const claude: Platform = {
@@ -19,18 +38,28 @@ export const claude: Platform = {
   },
 
   isSetup(): boolean {
-    const { ok, out } = run('claude plugin list 2>&1');
-    if (!ok) return false;
-    return out.includes('oh-my-mermaid');
+    const installed = getInstalledVersion();
+    if (!installed) return false;
+    const current = getPackageVersion();
+    if (!current) return true; // can't compare, assume OK
+    return installed === current;
   },
 
   async setup(): Promise<void> {
+    const installed = getInstalledVersion();
+
+    // Uninstall old version first if present
+    if (installed) {
+      const current = getPackageVersion();
+      process.stderr.write(`  Updating ${installed} → ${current}...\n`);
+      run('claude plugin uninstall oh-my-mermaid 2>&1');
+    }
+
     // Add marketplace (may already exist — ignore error)
     run('claude plugin marketplace add oh-my-mermaid/oh-my-mermaid');
 
     const { ok, out } = run('claude plugin install oh-my-mermaid 2>&1');
     if (!ok) {
-      // If marketplace add failed, suggest manual install
       process.stderr.write(`  Could not auto-install plugin. Run manually:\n`);
       process.stderr.write(`    claude plugin marketplace add oh-my-mermaid/oh-my-mermaid\n`);
       process.stderr.write(`    claude plugin install oh-my-mermaid\n`);

--- a/src/lib/platforms/cursor.ts
+++ b/src/lib/platforms/cursor.ts
@@ -11,6 +11,18 @@ function getCwd(): string {
   return process.cwd();
 }
 
+function getInstalledVersion(): string | null {
+  const manifestPath = path.join(getCwd(), PLUGIN_DIR, PLUGIN_FILE);
+  if (!fs.existsSync(manifestPath)) return null;
+
+  try {
+    const json = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    return typeof json.version === 'string' ? json.version : null;
+  } catch {
+    return null;
+  }
+}
+
 export const cursor: Platform = {
   name: 'Cursor',
   id: 'cursor',
@@ -27,7 +39,11 @@ export const cursor: Platform = {
   },
 
   isSetup(): boolean {
-    return fs.existsSync(path.join(getCwd(), PLUGIN_DIR, PLUGIN_FILE));
+    const installed = getInstalledVersion();
+    if (!installed) return false;
+    const current = getPackageVersion();
+    if (!current) return true;
+    return installed === current;
   },
 
   async setup(): Promise<void> {

--- a/src/lib/platforms/cursor.ts
+++ b/src/lib/platforms/cursor.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import type { Platform } from './types.js';
-import { getSkillsSource } from './utils.js';
+import { getSkillsSource, getPackageVersion } from './utils.js';
 
 const PLUGIN_DIR = '.cursor-plugin';
 const PLUGIN_FILE = 'plugin.json';
@@ -44,7 +44,7 @@ export const cursor: Platform = {
       name: 'oh-my-mermaid',
       displayName: 'oh-my-mermaid',
       description: 'Turn complex codebases into clear, navigable architecture diagrams',
-      version: '0.1.3',
+      version: getPackageVersion() || '0.0.0',
       author: { name: 'oh-my-mermaid' },
       homepage: 'https://github.com/oh-my-mermaid/oh-my-mermaid',
       license: 'MIT',

--- a/src/lib/platforms/utils.ts
+++ b/src/lib/platforms/utils.ts
@@ -23,3 +23,27 @@ export function getSkillsSource(): string | null {
   }
   return null;
 }
+
+/**
+ * Read the current package version from plugin.json or package.json.
+ * Works from both dist/ (production) and src/lib/platforms/ (dev).
+ */
+export function getPackageVersion(): string | null {
+  const candidates = [
+    path.join(__dirname, '..', '.claude-plugin', 'plugin.json'),       // from dist/
+    path.join(__dirname, '..', '..', '..', '.claude-plugin', 'plugin.json'), // from src/lib/platforms/
+    path.join(__dirname, '..', 'package.json'),                        // from dist/
+    path.join(__dirname, '..', '..', '..', 'package.json'),            // from src/lib/platforms/
+  ];
+
+  for (const candidate of candidates) {
+    const resolved = path.resolve(candidate);
+    if (fs.existsSync(resolved)) {
+      try {
+        const data = JSON.parse(fs.readFileSync(resolved, 'utf-8'));
+        if (data.version) return data.version;
+      } catch { /* ignore */ }
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- `omm setup` now compares installed plugin version against package version
- When versions mismatch, automatically uninstalls old version and reinstalls latest
- New skills (like `omm-view`) are picked up without manual uninstall/reinstall
- Added `getPackageVersion()` utility to read version from plugin.json or package.json

## Test plan
- [ ] `omm setup` with matching version → "already configured"
- [ ] `omm setup` with version mismatch → "Updating X.Y.Z → A.B.C..." + reinstall
- [ ] After update, new skills appear in Claude Code `/` menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)