### PR TITLE
fix: sync cli personal org credentials

### DIFF
--- a/src/__tests__/credentials.test.ts
+++ b/src/__tests__/credentials.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { syncHandleCredentials } from '../lib/cloud.js';
+
+describe('syncHandleCredentials', () => {
+  it('updates default_org when it still points at the old personal handle', () => {
+    expect(syncHandleCredentials({
+      handle: 'old-handle',
+      default_org: 'old-handle',
+      token: 'token',
+    }, 'new-handle')).toEqual({
+      handle: 'new-handle',
+      default_org: 'new-handle',
+      token: 'token',
+    });
+  });
+
+  it('preserves a team default_org when the user intentionally switched away', () => {
+    expect(syncHandleCredentials({
+      handle: 'old-handle',
+      default_org: 'acme-team',
+      token: 'token',
+    }, 'new-handle')).toEqual({
+      handle: 'new-handle',
+      default_org: 'acme-team',
+      token: 'token',
+    });
+  });
+
+  it('fills default_org for first-time credentials', () => {
+    expect(syncHandleCredentials({}, 'new-handle')).toEqual({
+      handle: 'new-handle',
+      default_org: 'new-handle',
+    });
+  });
+});

--- a/src/commands/org.ts
+++ b/src/commands/org.ts
@@ -1,4 +1,4 @@
-import { getToken, getHandle, getDefaultOrg, saveDefaultOrg, apiRequest } from '../lib/cloud.js';
+import { getToken, getDefaultOrg, saveDefaultOrg, saveHandle, apiRequest } from '../lib/cloud.js';
 
 export async function commandOrg(subcommand?: string, arg?: string): Promise<void> {
   const token = getToken();
@@ -35,6 +35,10 @@ async function orgList(): Promise<void> {
     handle?: string
   };
 
+  if (data.handle) {
+    saveHandle(data.handle);
+  }
+
   const orgs = data.orgs ?? [];
   const defaultOrg = getDefaultOrg();
 
@@ -62,7 +66,10 @@ async function orgSwitch(slug?: string): Promise<void> {
   // Validate the org exists and user has access
   const res = await apiRequest('GET', '/api/cli/orgs');
   if (res.ok) {
-    const data = await res.json() as { orgs?: Array<{ slug: string }> };
+    const data = await res.json() as { orgs?: Array<{ slug: string }>; handle?: string };
+    if (data.handle) {
+      saveHandle(data.handle);
+    }
     const orgs = data.orgs ?? [];
     if (!orgs.some(o => o.slug === slug)) {
       process.stderr.write(`error: org '${slug}' not found or you don't have access.\n`);

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -12,6 +12,18 @@ interface Credentials {
   default_org?: string;
 }
 
+export function syncHandleCredentials(creds: Credentials, handle: string): Credentials {
+  const next = { ...creds };
+  const previousHandle = next.handle ?? null;
+
+  next.handle = handle;
+  if (!next.default_org || next.default_org === previousHandle) {
+    next.default_org = handle;
+  }
+
+  return next;
+}
+
 export function getCredentialsPath(): string {
   return CREDENTIALS_FILE;
 }
@@ -56,12 +68,7 @@ export function saveToken(token: string): void {
 }
 
 export function saveHandle(handle: string): void {
-  const creds = readCredentials();
-  creds.handle = handle;
-  if (!creds.default_org) {
-    creds.default_org = handle;
-  }
-  writeCredentials(creds);
+  writeCredentials(syncHandleCredentials(readCredentials(), handle));
 }
 
 export function saveDefaultOrg(orgSlug: string): void {


### PR DESCRIPTION
## Summary
- sync stored CLI handle/default org when the personal handle changes
- refresh local credentials from the handle returned by org list/switch flows
- add regression coverage for personal-org credential migration

## Test Plan
- [x] npm test
- [x] npm run build