### PR TITLE
fix: Cursor setup fails to locate skills directory

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "oh-my-mermaid",
       "description": "Turn complex codebases into clear, navigable architecture diagrams with Mermaid",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "source": "./",
       "category": "development",
       "homepage": "https://github.com/oh-my-mermaid/oh-my-mermaid"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-mermaid",
   "description": "Turn complex codebases into clear, navigable architecture diagrams",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": {
     "name": "oh-my-mermaid"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-mermaid",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-mermaid",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-mermaid",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Architecture mirror for vibe coding — CLI + Claude Code skills",
   "type": "module",
   "bin": {

--- a/src/lib/platforms/utils.ts
+++ b/src/lib/platforms/utils.ts
@@ -11,8 +11,9 @@ const __dirname = path.dirname(__filename);
  */
 export function getSkillsSource(): string | null {
   const candidates = [
-    path.join(__dirname, '..', '..', 'skills'),          // from dist/lib/platforms/
-    path.join(__dirname, '..', '..', '..', 'skills'),     // from src/lib/platforms/
+    path.join(__dirname, '..', 'skills'),                  // from dist/ (flat build via tsup)
+    path.join(__dirname, '..', '..', 'skills'),            // from dist/lib/platforms/
+    path.join(__dirname, '..', '..', '..', 'skills'),      // from src/lib/platforms/
   ];
 
   for (const candidate of candidates) {


### PR DESCRIPTION
## Summary
- `getSkillsSource()`가 flat dist 빌드(tsup) 경로를 고려하지 않아 Cursor 등 플랫폼 setup 시 `Could not locate skills directory` 에러 발생
- `dist/` 기준 `../skills/` 경로 후보 추가로 해결
- Version bump to 0.1.7

## Test plan
- [x] `npm run build` 성공 확인
- [x] `dist/` 기준 skills 경로 resolve 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)