### PR TITLE
docs: fix README centering + add ko/ja/zh translations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,139 @@
+[English](./README.md) | [한국어](./README.ko.md) | [日本語](./README.ja.md) | [中文](./README.zh.md)
+
+> このドキュメントは英語のREADMEから翻訳されたものです。一部の表現が不自然な場合があります。
+
+<p align="center">
+  <img src="./docs/logo.jpg" alt="omm logo" width="80"/>
+  <br/>
+  <br/><strong>Oh-my-mermaid</strong>
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/oh-my-mermaid"><img src="https://img.shields.io/npm/v/oh-my-mermaid" alt="npm version"/></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"/></a>
+</p>
+
+<p align="center">
+  AIは数秒でコードを書きます。人間が理解するには数時間かかります。<br/>
+  理解をスキップすると、コードベースはブラックボックスになります — あなた自身にとっても。<br/><br/>
+  <strong>ommがそのギャップを埋めます — AIが生成した、人間のためのアーキテクチャドキュメント。</strong>
+</p>
+
+---
+
+## クイックスタート
+
+ターミナルに貼り付けてください：
+
+```bash
+npm install -g oh-my-mermaid && omm setup
+```
+
+AIコーディングツールを開き、`/omm-scan`スキルを実行：
+
+```
+/omm-scan
+```
+
+以上です。結果を表示：
+
+```bash
+omm view
+```
+
+## 例
+
+> ommが自分自身をスキャンしました。これがその結果です。
+
+<table><tr>
+<td width="50%"><img src="./docs/screenshot.png" alt="omm viewer"/></td>
+<td width="50%"><img src="./docs/demo.gif" alt="omm scan demo"/></td>
+</tr></table>
+
+## 仕組み
+
+AIがコードベースを分析し、**パースペクティブ**を生成します — アーキテクチャを見るための様々なレンズ（構造、データフロー、外部連携など）。各パースペクティブにはMermaidダイアグラムとドキュメントフィールドが含まれます。
+
+すべてのノードが**再帰的に分析**されます。複雑なノードは独自のダイアグラムを持つネストされた子エレメントになります。シンプルなノードはリーフとして残ります。ファイルシステムがツリーを直接反映します：
+
+```
+.omm/
+├── overall-architecture/           ← パースペクティブ
+│   ├── description.md
+│   ├── diagram.mmd
+│   ├── context.md
+│   ├── main-process/               ← ネストされたエレメント
+│   │   ├── description.md
+│   │   ├── diagram.mmd
+│   │   └── auth-service/           ← より深いネスト
+│   │       └── ...
+│   └── renderer/
+│       └── ...
+├── data-flow/
+└── external-integrations/
+```
+
+ビューアはファイルシステムからネストを自動検出します — 子を持つエレメントは展開可能なグループとして、それ以外はノードとしてレンダリングされます。
+
+各エレメントは最大7つのフィールドを持ちます：`description`、`diagram`、`context`、`constraint`、`concern`、`todo`、`note`。
+
+## CLI
+
+```bash
+omm setup                          # AIツールにスキルを登録
+omm view                           # インタラクティブビューアを開く
+omm config language ja             # コンテンツ言語を設定
+omm update                         # 最新バージョンに更新
+```
+
+完全なコマンドリストは`omm help`を参照してください。
+
+## スキル
+
+スキルは**AIコーディングツール内で**実行するコマンドです（ターミナルではありません）。`/`で始まります。
+
+| スキル | 機能 |
+| --- | --- |
+| `/omm-scan` | コードベース分析 → アーキテクチャドキュメント生成 |
+| `/omm-push` | ログイン + リンク + クラウドプッシュを一度に |
+
+## クラウド
+
+[ohmymermaid.com](https://ohmymermaid.com)を通じてアーキテクチャをクラウドに保存できます。
+
+```bash
+omm login && omm link && omm push
+```
+
+デフォルトではプライベートです。チームと共有したり、[この例](https://ohmymermaid.com/share/c47e20a7063c231760361ed9cb9ec4b6)のように公開できます。
+
+## 対応AIツール
+
+| プラットフォーム | セットアップ |
+| --- | --- |
+| Claude Code | `omm setup claude` |
+| Codex | `omm setup codex` |
+| Cursor | `omm setup cursor` |
+| OpenClaw | `omm setup openclaw` |
+| Antigravity | `omm setup antigravity` |
+
+`omm setup`を実行すると、インストール済みのすべてのツールを自動検出して設定します。
+
+## ロードマップ
+
+[docs/ROADMAP.md](./docs/ROADMAP.md)を参照してください。
+
+## 開発 & 貢献
+
+```bash
+git clone https://github.com/oh-my-mermaid/oh-my-mermaid.git
+cd oh-my-mermaid
+npm install && npm run build
+npm test
+```
+
+IssueとPRを歓迎します。[Conventional Commits](https://www.conventionalcommits.org/)を使用してください。
+
+## ライセンス
+
+[MIT](./LICENSE)

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,139 @@
+[English](./README.md) | [한국어](./README.ko.md) | [日本語](./README.ja.md) | [中文](./README.zh.md)
+
+> 이 문서는 영어 README를 번역한 것입니다. 일부 표현이 부자연스러울 수 있습니다.
+
+<p align="center">
+  <img src="./docs/logo.jpg" alt="omm logo" width="80"/>
+  <br/>
+  <br/><strong>Oh-my-mermaid</strong>
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/oh-my-mermaid"><img src="https://img.shields.io/npm/v/oh-my-mermaid" alt="npm version"/></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"/></a>
+</p>
+
+<p align="center">
+  AI는 몇 초 만에 코드를 작성합니다. 사람이 이해하는 데는 몇 시간이 걸립니다.<br/>
+  이해를 건너뛰면, 코드베이스는 블랙박스가 됩니다 — 본인에게조차.<br/><br/>
+  <strong>omm이 그 격차를 해소합니다 — AI가 생성한, 사람을 위한 아키텍처 문서.</strong>
+</p>
+
+---
+
+## 빠른 시작
+
+터미널에 붙여넣기:
+
+```bash
+npm install -g oh-my-mermaid && omm setup
+```
+
+AI 코딩 도구를 열고 `/omm-scan` 스킬을 실행:
+
+```
+/omm-scan
+```
+
+끝. 결과 보기:
+
+```bash
+omm view
+```
+
+## 예시
+
+> omm이 자기 자신을 스캔했습니다. 이것이 결과입니다.
+
+<table><tr>
+<td width="50%"><img src="./docs/screenshot.png" alt="omm viewer"/></td>
+<td width="50%"><img src="./docs/demo.gif" alt="omm scan demo"/></td>
+</tr></table>
+
+## 작동 방식
+
+AI가 코드베이스를 분석하고 **관점(perspective)** 을 생성합니다 — 아키텍처를 바라보는 다양한 렌즈(구조, 데이터 흐름, 외부 연동 등). 각 관점에는 Mermaid 다이어그램과 문서 필드가 포함됩니다.
+
+모든 노드는 **재귀적으로 분석**됩니다. 복잡한 노드는 자체 다이어그램을 가진 중첩 자식 element가 됩니다. 단순한 노드는 리프로 남습니다. 파일시스템이 트리를 직접 반영합니다:
+
+```
+.omm/
+├── overall-architecture/           ← 관점
+│   ├── description.md
+│   ├── diagram.mmd
+│   ├── context.md
+│   ├── main-process/               ← 중첩 element
+│   │   ├── description.md
+│   │   ├── diagram.mmd
+│   │   └── auth-service/           ← 더 깊은 중첩
+│   │       └── ...
+│   └── renderer/
+│       └── ...
+├── data-flow/
+└── external-integrations/
+```
+
+뷰어는 파일시스템에서 중첩을 자동 감지합니다 — 자식이 있는 element는 확장 가능한 그룹으로, 나머지는 노드로 렌더링됩니다.
+
+각 element는 최대 7개 필드를 가집니다: `description`, `diagram`, `context`, `constraint`, `concern`, `todo`, `note`.
+
+## CLI
+
+```bash
+omm setup                          # AI 도구에 스킬 등록
+omm view                           # 인터랙티브 뷰어 열기
+omm config language ko             # 콘텐츠 언어 설정
+omm update                         # 최신 버전으로 업데이트
+```
+
+전체 명령어는 `omm help`를 참고하세요.
+
+## 스킬
+
+스킬은 **AI 코딩 도구 안에서** 실행하는 명령어입니다 (터미널이 아닙니다). `/`로 시작합니다.
+
+| 스킬 | 기능 |
+| --- | --- |
+| `/omm-scan` | 코드베이스 분석 → 아키텍처 문서 생성 |
+| `/omm-push` | 로그인 + 연결 + 클라우드 푸시를 한 번에 |
+
+## 클라우드
+
+[ohmymermaid.com](https://ohmymermaid.com)을 통해 아키텍처를 클라우드에 저장할 수 있습니다.
+
+```bash
+omm login && omm link && omm push
+```
+
+기본적으로 비공개입니다. 팀과 공유하거나, [이 예시](https://ohmymermaid.com/share/c47e20a7063c231760361ed9cb9ec4b6)처럼 공개할 수 있습니다.
+
+## 지원 AI 도구
+
+| 플랫폼 | 설정 |
+| --- | --- |
+| Claude Code | `omm setup claude` |
+| Codex | `omm setup codex` |
+| Cursor | `omm setup cursor` |
+| OpenClaw | `omm setup openclaw` |
+| Antigravity | `omm setup antigravity` |
+
+`omm setup`을 실행하면 설치된 모든 도구를 자동 감지하고 설정합니다.
+
+## 로드맵
+
+[docs/ROADMAP.md](./docs/ROADMAP.md)를 참고하세요.
+
+## 개발 & 기여
+
+```bash
+git clone https://github.com/oh-my-mermaid/oh-my-mermaid.git
+cd oh-my-mermaid
+npm install && npm run build
+npm test
+```
+
+이슈와 PR을 환영합니다. [Conventional Commits](https://www.conventionalcommits.org/)를 사용해주세요.
+
+## 라이선스
+
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <img src="./docs/logo.jpg" alt="omm logo" width="80"/>
   <br/>
-  <h1>Oh-my-mermaid</h1>
+  <br/><strong>Oh-my-mermaid</strong>
 </p>
 
 <p align="center">

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,139 @@
+[English](./README.md) | [한국어](./README.ko.md) | [日本語](./README.ja.md) | [中文](./README.zh.md)
+
+> 本文档翻译自英文 README。部分表述可能不够自然。
+
+<p align="center">
+  <img src="./docs/logo.jpg" alt="omm logo" width="80"/>
+  <br/>
+  <br/><strong>Oh-my-mermaid</strong>
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/oh-my-mermaid"><img src="https://img.shields.io/npm/v/oh-my-mermaid" alt="npm version"/></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"/></a>
+</p>
+
+<p align="center">
+  AI 几秒钟就能写出代码。人类理解它需要几个小时。<br/>
+  跳过理解，代码库就变成了黑盒 — 即使对你自己而言。<br/><br/>
+  <strong>omm 弥合了这个差距 — 由 AI 生成的、为人类准备的架构文档。</strong>
+</p>
+
+---
+
+## 快速开始
+
+在终端中粘贴：
+
+```bash
+npm install -g oh-my-mermaid && omm setup
+```
+
+打开你的 AI 编码工具，使用 `/omm-scan` 技能：
+
+```
+/omm-scan
+```
+
+就这样。查看结果：
+
+```bash
+omm view
+```
+
+## 示例
+
+> omm 扫描了自己。这是它发现的结果。
+
+<table><tr>
+<td width="50%"><img src="./docs/screenshot.png" alt="omm viewer"/></td>
+<td width="50%"><img src="./docs/demo.gif" alt="omm scan demo"/></td>
+</tr></table>
+
+## 工作原理
+
+AI 分析代码库并生成 **视角（perspective）** — 观察架构的不同镜头（结构、数据流、外部集成等）。每个视角包含 Mermaid 图表和文档字段。
+
+每个节点都会被**递归分析**。复杂的节点会成为具有自己图表的嵌套子元素。简单的节点保持为叶子节点。文件系统直接反映树结构：
+
+```
+.omm/
+├── overall-architecture/           ← 视角
+│   ├── description.md
+│   ├── diagram.mmd
+│   ├── context.md
+│   ├── main-process/               ← 嵌套元素
+│   │   ├── description.md
+│   │   ├── diagram.mmd
+│   │   └── auth-service/           ← 更深层嵌套
+│   │       └── ...
+│   └── renderer/
+│       └── ...
+├── data-flow/
+└── external-integrations/
+```
+
+查看器自动从文件系统检测嵌套 — 有子元素的元素渲染为可展开的组，其他渲染为节点。
+
+每个元素最多包含 7 个字段：`description`、`diagram`、`context`、`constraint`、`concern`、`todo`、`note`。
+
+## CLI
+
+```bash
+omm setup                          # 向 AI 工具注册技能
+omm view                           # 打开交互式查看器
+omm config language zh             # 设置内容语言
+omm update                         # 更新到最新版本
+```
+
+完整命令列表请运行 `omm help`。
+
+## 技能
+
+技能是在 **AI 编码工具内部**运行的命令（不是终端）。以 `/` 开头。
+
+| 技能 | 功能 |
+| --- | --- |
+| `/omm-scan` | 分析代码库 → 生成架构文档 |
+| `/omm-push` | 一步完成登录 + 链接 + 推送到云端 |
+
+## 云端
+
+通过 [ohmymermaid.com](https://ohmymermaid.com) 将架构存储在云端。
+
+```bash
+omm login && omm link && omm push
+```
+
+默认为私有。可以与团队共享，或像[这个示例](https://ohmymermaid.com/share/c47e20a7063c231760361ed9cb9ec4b6)一样公开。
+
+## 支持的 AI 工具
+
+| 平台 | 设置 |
+| --- | --- |
+| Claude Code | `omm setup claude` |
+| Codex | `omm setup codex` |
+| Cursor | `omm setup cursor` |
+| OpenClaw | `omm setup openclaw` |
+| Antigravity | `omm setup antigravity` |
+
+运行 `omm setup` 自动检测并配置所有已安装的工具。
+
+## 路线图
+
+请参阅 [docs/ROADMAP.md](./docs/ROADMAP.md)。
+
+## 开发 & 贡献
+
+```bash
+git clone https://github.com/oh-my-mermaid/oh-my-mermaid.git
+cd oh-my-mermaid
+npm install && npm run build
+npm test
+```
+
+欢迎提交 Issue 和 PR。请使用 [Conventional Commits](https://www.conventionalcommits.org/)。
+
+## 许可证
+
+[MIT](./LICENSE)


### PR DESCRIPTION
## Summary

- Fix title centering on GitHub (`<h1>` → `<strong>` inside `<p align="center">`)
- Add translated READMEs: Korean, Japanese, Chinese
- Language links at top of all READMEs
- Translation disclaimer per CLAUDE.md rules

## Test plan

- [x] Check title centering on GitHub
- [x] Language links work across all 4 READMEs
- [x] Translations include disclaimer

🤖 Generated with [Claude Code](https://claude.com/claude-code)