### PR TITLE
fix: use cross-platform command for binary detection on Windows

### DIFF
--- a/src/lib/platforms/antigravity.ts
+++ b/src/lib/platforms/antigravity.ts
@@ -1,9 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execSync } from 'node:child_process';
 import type { Platform } from './types.js';
-import { getSkillsSource } from './utils.js';
+import { getSkillsSource, hasCommand } from './utils.js';
 
 const SKILLS_TARGET = path.join(os.homedir(), '.gemini', 'antigravity', 'skills', 'oh-my-mermaid');
 
@@ -12,12 +11,7 @@ export const antigravity: Platform = {
   id: 'antigravity',
 
   detect(): boolean {
-    try {
-      execSync('which antigravity', { stdio: 'ignore' });
-      return true;
-    } catch {
-      return false;
-    }
+    return hasCommand('antigravity');
   },
 
   isSetup(): boolean {

--- a/src/lib/platforms/claude.ts
+++ b/src/lib/platforms/claude.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import type { Platform } from './types.js';
-import { getPackageVersion } from './utils.js';
+import { getPackageVersion, hasCommand } from './utils.js';
 
 function run(cmd: string): { ok: boolean; out: string } {
   try {
@@ -34,7 +34,7 @@ export const claude: Platform = {
   id: 'claude',
 
   detect(): boolean {
-    return run('which claude').ok;
+    return hasCommand('claude');
   },
 
   isSetup(): boolean {

--- a/src/lib/platforms/codex.ts
+++ b/src/lib/platforms/codex.ts
@@ -1,9 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execSync } from 'node:child_process';
 import type { Platform } from './types.js';
-import { getSkillsSource } from './utils.js';
+import { getSkillsSource, hasCommand } from './utils.js';
 
 const SKILLS_TARGET = path.join(os.homedir(), '.agents', 'skills', 'oh-my-mermaid');
 
@@ -12,12 +11,7 @@ export const codex: Platform = {
   id: 'codex',
 
   detect(): boolean {
-    try {
-      execSync('which codex', { stdio: 'ignore' });
-      return true;
-    } catch {
-      return false;
-    }
+    return hasCommand('codex');
   },
 
   isSetup(): boolean {

--- a/src/lib/platforms/cursor.ts
+++ b/src/lib/platforms/cursor.ts
@@ -1,8 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { execSync } from 'node:child_process';
 import type { Platform } from './types.js';
-import { getSkillsSource, getAgentsSource, getPackageVersion } from './utils.js';
+import { getSkillsSource, getAgentsSource, getPackageVersion, hasCommand } from './utils.js';
 
 const PLUGIN_DIR = '.cursor-plugin';
 const PLUGIN_FILE = 'plugin.json';
@@ -43,13 +42,9 @@ export const cursor: Platform = {
 
   detect(): boolean {
     // Cursor is detected if the binary exists or we're inside a Cursor workspace
-    try {
-      execSync('which cursor', { stdio: 'ignore' });
-      return true;
-    } catch {
-      // Also detect if .cursor/ directory exists in project
-      return fs.existsSync(path.join(getCwd(), '.cursor'));
-    }
+    if (hasCommand('cursor')) return true;
+    // Also detect if .cursor/ directory exists in project
+    return fs.existsSync(path.join(getCwd(), '.cursor'));
   },
 
   isSetup(): boolean {

--- a/src/lib/platforms/openclaw.ts
+++ b/src/lib/platforms/openclaw.ts
@@ -1,9 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execSync } from 'node:child_process';
 import type { Platform } from './types.js';
-import { getSkillsSource } from './utils.js';
+import { getSkillsSource, hasCommand } from './utils.js';
 
 const SKILLS_TARGET = path.join(os.homedir(), '.openclaw', 'skills', 'oh-my-mermaid');
 
@@ -12,12 +11,7 @@ export const openclaw: Platform = {
   id: 'openclaw',
 
   detect(): boolean {
-    try {
-      execSync('which openclaw', { stdio: 'ignore' });
-      return true;
-    } catch {
-      return false;
-    }
+    return hasCommand('openclaw');
   },
 
   isSetup(): boolean {

--- a/src/lib/platforms/utils.ts
+++ b/src/lib/platforms/utils.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -44,6 +45,20 @@ export function getAgentsSource(): string | null {
     }
   }
   return null;
+}
+
+/**
+ * Cross-platform check whether a binary is available on PATH.
+ * Uses `where` on Windows, `which` on Unix/macOS.
+ */
+export function hasCommand(bin: string): boolean {
+  const cmd = process.platform === 'win32' ? `where ${bin}` : `which ${bin}`;
+  try {
+    execSync(cmd, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
**Problem**: On Windows, omm setup claude always fails with "Claude Code is not installed" because all platform detect() methods use the Unix-only which command.
**Fix**: Added a cross-platform hasCommand() utility that uses where on Windows and which on Unix/macOS. Updated all 5 platform implementations to use it.