### PR TITLE
test: add Claude setup detection coverage

### DIFF
--- a/src/__tests__/claude.test.ts
+++ b/src/__tests__/claude.test.ts
@@ -1,0 +1,70 @@
+import { execSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getPackageVersion = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('../lib/platforms/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/platforms/utils.js')>(
+    '../lib/platforms/utils.js',
+  );
+  return {
+    ...actual,
+    getPackageVersion,
+  };
+});
+
+describe('claude platform version-aware setup detection', () => {
+  beforeEach(() => {
+    vi.mocked(execSync).mockReset();
+    getPackageVersion.mockReset();
+    getPackageVersion.mockReturnValue('0.2.0');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false when claude plugin list is unavailable', async () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error('claude not available');
+    });
+
+    const { claude } = await import('../lib/platforms/claude.js');
+
+    expect(claude.isSetup()).toBe(false);
+  });
+
+  it('returns false when the installed Claude plugin version is stale', async () => {
+    vi.mocked(execSync).mockReturnValue(
+      Buffer.from('oh-my-mermaid\n  Version: 0.1.9\n'),
+    );
+
+    const { claude } = await import('../lib/platforms/claude.js');
+
+    expect(claude.isSetup()).toBe(false);
+  });
+
+  it('ignores oh-my-claudecode entries when checking setup state', async () => {
+    vi.mocked(execSync).mockReturnValue(
+      Buffer.from('oh-my-claudecode\n  Version: 0.2.0\nanother-plugin\n  Version: 0.2.0\n'),
+    );
+
+    const { claude } = await import('../lib/platforms/claude.js');
+
+    expect(claude.isSetup()).toBe(false);
+  });
+
+  it('returns true when the installed Claude plugin version matches the package version', async () => {
+    vi.mocked(execSync).mockReturnValue(
+      Buffer.from('oh-my-mermaid\n  Version: 0.2.0\n'),
+    );
+
+    const { claude } = await import('../lib/platforms/claude.js');
+
+    expect(claude.isSetup()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression coverage for Claude Code setup detection
- cover the cases where the plugin list is unavailable, the installed plugin version is stale, and the installed version matches the current package version
- add a guard case to ensure similarly named plugins do not count as the oh-my-mermaid plugin

## Why
The repository already has version-aware setup coverage for Cursor, but the Claude platform has similar setup-detection logic without equivalent tests. This keeps that logic safer to refactor and aligns the two setup paths.

## Verification
- ran the targeted claude test file locally
- ran the full test suite locally
- ran the build locally