### PR TITLE
feat: add Hermes Agent platform support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -116,6 +116,7 @@ omm login && omm link && omm push
 | Cursor | `omm setup cursor` |
 | OpenClaw | `omm setup openclaw` |
 | Antigravity | `omm setup antigravity` |
+| Hermes | `omm setup hermes` |
 
 `omm setup`を実行すると、インストール済みのすべてのツールを自動検出して設定します。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -116,6 +116,7 @@ omm login && omm link && omm push
 | Cursor | `omm setup cursor` |
 | OpenClaw | `omm setup openclaw` |
 | Antigravity | `omm setup antigravity` |
+| Hermes | `omm setup hermes` |
 
 `omm setup`을 실행하면 설치된 모든 도구를 자동 감지하고 설정합니다.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ It's private by default. Share with your team, or make it public like [this exam
 | Cursor | `omm setup cursor` |
 | OpenClaw | `omm setup openclaw` |
 | Antigravity | `omm setup antigravity` |
+| Hermes | `omm setup hermes` |
 
 Run `omm setup` to auto-detect and configure all installed tools.
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -116,6 +116,7 @@ Varsayılan olarak özeldir. İsterseniz ekibinizle paylaşabilir ya da [bu örn
 | Cursor | `omm setup cursor` |
 | OpenClaw | `omm setup openclaw` |
 | Antigravity | `omm setup antigravity` |
+| Hermes | `omm setup hermes` |
 
 `omm setup` komutu, yüklü tüm araçları otomatik olarak algılar ve yapılandırır.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -116,6 +116,7 @@ omm login && omm link && omm push
 | Cursor | `omm setup cursor` |
 | OpenClaw | `omm setup openclaw` |
 | Antigravity | `omm setup antigravity` |
+| Hermes | `omm setup hermes` |
 
 运行 `omm setup` 自动检测并配置所有已安装的工具。
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,10 @@
 # Roadmap
 
+## Recently Shipped
+
+### Hermes Agent support
+Integrated with [Hermes Agent](https://github.com/NousResearch/hermes-agent) — `omm setup hermes` symlinks the skills directory into `~/.hermes/skills/oh-my-mermaid`, making the omm skills discoverable by any Hermes profile.
+
 ## Planned
 
 ### Sub-agent scan pipeline

--- a/skills/omm-push/SKILL.md
+++ b/skills/omm-push/SKILL.md
@@ -3,6 +3,16 @@ name: omm-push
 description: Push architecture docs to oh-my-mermaid cloud. Handles login, link, and push workflow with error guidance. Use when the user says "omm push", "push to cloud", "deploy architecture", or "share architecture".
 ---
 
+## Platform-Specific Tool Names
+
+Tool names vary by platform. The workflow and logic below are identical — only the tool identifiers change.
+
+| Action | Claude Code / Codex / OpenClaw | Hermes |
+| --- | --- | --- |
+| Run commands | Bash | `terminal` |
+
+When running under Hermes, substitute `terminal` anywhere "Bash" is referenced.
+
 # omm-push — Cloud Push Workflow
 
 ## Purpose

--- a/skills/omm-scan/SKILL.md
+++ b/skills/omm-scan/SKILL.md
@@ -3,6 +3,19 @@ name: omm-scan
 description: Scan codebase architecture and generate/update .omm/ documentation. Use when the user says "omm scan", "scan architecture", "update architecture", "refresh diagrams".
 ---
 
+## Platform-Specific Tool Names
+
+Tool names vary by platform. The workflow and logic below are identical — only the tool identifiers change.
+
+| Action | Claude Code / Codex / OpenClaw | Hermes |
+| --- | --- | --- |
+| Explore files | Glob | `search_files` (target=files) |
+| Read files | Read | `read_file` |
+| Search content | Grep | `search_files` (target=content) |
+| Run commands | Bash | `terminal` |
+
+When running under Hermes, substitute the tool names accordingly.
+
 # omm-scan — Perspective-Based Architecture Scanner
 
 ## Purpose

--- a/skills/omm-view/SKILL.md
+++ b/skills/omm-view/SKILL.md
@@ -4,6 +4,16 @@ description: Start the omm web viewer to explore architecture diagrams in the br
 argument-hint: "[--port <port>]"
 ---
 
+## Platform-Specific Tool Names
+
+Tool names vary by platform. The workflow and logic below are identical — only the tool identifiers change.
+
+| Action | Claude Code / Codex / OpenClaw | Hermes |
+| --- | --- | --- |
+| Run commands | Bash | `terminal` |
+
+When running under Hermes, substitute `terminal` anywhere "Bash" is referenced.
+
 # omm-view — Architecture Viewer
 
 ## Purpose

--- a/src/__tests__/hermes.test.ts
+++ b/src/__tests__/hermes.test.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hasCommand = vi.fn();
+const getSkillsSource = vi.fn();
+
+vi.mock('../lib/platforms/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/platforms/utils.js')>('../lib/platforms/utils.js');
+  return {
+    ...actual,
+    hasCommand,
+    getSkillsSource,
+  };
+});
+
+describe('hermes platform', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omm-hermes-'));
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tmpDir;
+    process.env.USERPROFILE = tmpDir;
+    vi.resetModules();
+    hasCommand.mockReset();
+    getSkillsSource.mockReset();
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalUserProfile;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detect() returns false when the hermes binary is not installed', async () => {
+    hasCommand.mockReturnValue(false);
+
+    const { hermes } = await import('../lib/platforms/hermes.js');
+
+    expect(hermes.detect()).toBe(false);
+  });
+
+  it('detect() returns true when hasCommand reports true', async () => {
+    hasCommand.mockReturnValue(true);
+
+    const { hermes } = await import('../lib/platforms/hermes.js');
+
+    expect(hermes.detect()).toBe(true);
+  });
+
+  it('isSetup() returns false when the skills symlink is absent', async () => {
+    const { hermes } = await import('../lib/platforms/hermes.js');
+
+    expect(hermes.isSetup()).toBe(false);
+  });
+
+  it('isSetup() returns true after setup() creates the symlink', async () => {
+    const sourceDir = path.join(tmpDir, 'source-skills');
+    fs.mkdirSync(sourceDir, { recursive: true });
+    getSkillsSource.mockReturnValue(sourceDir);
+
+    const { hermes } = await import('../lib/platforms/hermes.js');
+    await hermes.setup();
+
+    const targetPath = path.join(tmpDir, '.hermes', 'skills', 'oh-my-mermaid');
+    expect(hermes.isSetup()).toBe(true);
+    expect(fs.lstatSync(targetPath).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(targetPath)).toBe(sourceDir);
+  });
+
+  it('teardown() removes the symlink', async () => {
+    const sourceDir = path.join(tmpDir, 'source-skills');
+    fs.mkdirSync(sourceDir, { recursive: true });
+    getSkillsSource.mockReturnValue(sourceDir);
+
+    const { hermes } = await import('../lib/platforms/hermes.js');
+    await hermes.setup();
+
+    const targetPath = path.join(tmpDir, '.hermes', 'skills', 'oh-my-mermaid');
+    expect(fs.existsSync(targetPath)).toBe(true);
+
+    hermes.teardown();
+
+    expect(fs.existsSync(targetPath)).toBe(false);
+  });
+});

--- a/src/lib/platforms/hermes.ts
+++ b/src/lib/platforms/hermes.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { Platform } from './types.js';
+import { getSkillsSource, hasCommand } from './utils.js';
+
+const SKILLS_TARGET = path.join(os.homedir(), '.hermes', 'skills', 'oh-my-mermaid');
+
+export const hermes: Platform = {
+  name: 'Hermes',
+  id: 'hermes',
+
+  detect(): boolean {
+    return hasCommand('hermes');
+  },
+
+  isSetup(): boolean {
+    return fs.existsSync(SKILLS_TARGET);
+  },
+
+  async setup(): Promise<void> {
+    const source = getSkillsSource();
+    if (!source) {
+      process.stderr.write('  Could not locate skills directory.\n');
+      return;
+    }
+
+    fs.mkdirSync(path.dirname(SKILLS_TARGET), { recursive: true });
+
+    if (fs.existsSync(SKILLS_TARGET)) {
+      fs.rmSync(SKILLS_TARGET, { recursive: true });
+    }
+    fs.symlinkSync(source, SKILLS_TARGET, 'dir');
+    process.stderr.write(`  Symlinked skills → ${SKILLS_TARGET}\n`);
+  },
+
+  teardown(): void {
+    if (fs.existsSync(SKILLS_TARGET)) {
+      fs.rmSync(SKILLS_TARGET, { recursive: true });
+    }
+  },
+};

--- a/src/lib/platforms/index.ts
+++ b/src/lib/platforms/index.ts
@@ -4,10 +4,11 @@ import { codex } from './codex.js';
 import { cursor } from './cursor.js';
 import { openclaw } from './openclaw.js';
 import { antigravity } from './antigravity.js';
+import { hermes } from './hermes.js';
 
 export type { Platform };
 
-export const ALL_PLATFORMS: Platform[] = [claude, codex, cursor, openclaw, antigravity];
+export const ALL_PLATFORMS: Platform[] = [claude, codex, cursor, openclaw, antigravity, hermes];
 
 export function getPlatformById(id: string): Platform | undefined {
   return ALL_PLATFORMS.find(p => p.id === id);


### PR DESCRIPTION
## Summary
Adds [Hermes Agent](https://github.com/NousResearch/hermes-agent) as a new platform for `omm setup`. Running `omm setup hermes` symlinks the bundled skills into `~/.hermes/skills/oh-my-mermaid`, making `/omm-scan`, `/omm-push`, and `/omm-view` discoverable by any Hermes profile.

## What's Hermes?
Hermes is Nous Research's open-source AI agent. It's [agentskills.io](https://agentskills.io)-compatible and ships with a built-in `hermes claw migrate` path from OpenClaw, so its skill-discovery shape is close to OpenClaw's — a single symlink is enough to integrate.

## Implementation

- **`src/lib/platforms/hermes.ts`** (new) — mirrors `openclaw.ts`. `detect()` via `hasCommand('hermes')`; `setup()` symlinks the repo's `skills/` dir into `~/.hermes/skills/oh-my-mermaid`; `teardown()` removes it.
- **`src/lib/platforms/index.ts`** — registers `hermes` in `ALL_PLATFORMS`.
- **`skills/omm-{scan,push,view}/SKILL.md`** — a "Platform-Specific Tool Names" table so Hermes users know which tool names map to the ones the skill narrates. Verified against Hermes source:
  - `Read` → `read_file` (`tools/file_tools.py:975`)
  - `Bash` → `terminal` (`tools/terminal_tool.py:2070`)
  - `Glob` → `search_files` with `target=files` (`tools/file_tools.py:978`)
  - `Grep` → `search_files` with `target=content`
- **`src/__tests__/hermes.test.ts`** — 5 new cases; full suite 42/42 passing.
- **Docs** — `Hermes` row added to the Supported AI Tools table in `README.md` and all 4 translations (per repo's README localization policy); `docs/ROADMAP.md` notes that Hermes support shipped.

## Skills path note
Hermes stores all skills globally at `~/.hermes/skills/`, not per-profile. Confirmed from Hermes source (`tools/skills_sync.py:36`, `tools/skills_tool.py:84`, `tools/skill_manager_tool.py:101`). Profiles (`~/.hermes/profiles/<name>/`) isolate config/sessions/logs but share the global skills dir.

## How to use
```bash
npm install -g oh-my-mermaid
omm setup hermes
```

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 42/42 passing (including 5 new `hermes.test.ts` cases)
- [x] Smoke-tested end-to-end in a stubbed sandbox (fake `hermes` binary on `PATH`, `HOME` redirected to a tempdir): `omm setup hermes` created the expected symlink, `--teardown` removed it, idempotent re-run reported "already configured"
- [ ] Not tested against a live Hermes install — the Hermes binary was not available in the environment this PR was authored from. The integration is pattern-verified against the Hermes source code. A reviewer with `hermes` installed can validate end-to-end by running `omm setup hermes` and confirming `ls -la ~/.hermes/skills/oh-my-mermaid` resolves to the oh-my-mermaid `skills/` dir.