### PR TITLE
feat: add 3 new IDE platforms + viewer pan/zoom/dblclick improvements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "oh-my-mermaid",
       "description": "Turn complex codebases into clear, navigable architecture diagrams with Mermaid",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "source": "./",
       "category": "development",
       "homepage": "https://github.com/oh-my-mermaid/oh-my-mermaid"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-mermaid",
   "description": "Turn complex codebases into clear, navigable architecture diagrams",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "oh-my-mermaid"
   },

--- a/README.ja.md
+++ b/README.ja.md
@@ -116,6 +116,9 @@ omm login && omm link && omm push
 | Cursor | `omm setup cursor` |
 | OpenClaw | `omm setup openclaw` |
 | Antigravity | `omm setup antigravity` |
+| OpenCode | `omm setup opencode` |
+| pi (pi.dev) | `omm setup pi` |
+| Oh my Pi (omp) | `omm setup omp` |
 
 `omm setup`を実行すると、インストール済みのすべてのツールを自動検出して設定します。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -116,6 +116,9 @@ omm login && omm link && omm push
 | Cursor | `omm setup cursor` |
 | OpenClaw | `omm setup openclaw` |
 | Antigravity | `omm setup antigravity` |
+| OpenCode | `omm setup opencode` |
+| pi (pi.dev) | `omm setup pi` |
+| Oh my Pi (omp) | `omm setup omp` |
 
 `omm setup`을 실행하면 설치된 모든 도구를 자동 감지하고 설정합니다.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ It's private by default. Share with your team, or make it public like [this exam
 | Cursor | `omm setup cursor` |
 | OpenClaw | `omm setup openclaw` |
 | Antigravity | `omm setup antigravity` |
+| OpenCode | `omm setup opencode` |
+| pi (pi.dev) | `omm setup pi` |
+| Oh my Pi (omp) | `omm setup omp` |
 
 Run `omm setup` to auto-detect and configure all installed tools.
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -116,6 +116,9 @@ Varsayılan olarak özeldir. İsterseniz ekibinizle paylaşabilir ya da [bu örn
 | Cursor | `omm setup cursor` |
 | OpenClaw | `omm setup openclaw` |
 | Antigravity | `omm setup antigravity` |
+| OpenCode | `omm setup opencode` |
+| pi (pi.dev) | `omm setup pi` |
+| Oh my Pi (omp) | `omm setup omp` |
 
 `omm setup` komutu, yüklü tüm araçları otomatik olarak algılar ve yapılandırır.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -116,6 +116,9 @@ omm login && omm link && omm push
 | Cursor | `omm setup cursor` |
 | OpenClaw | `omm setup openclaw` |
 | Antigravity | `omm setup antigravity` |
+| OpenCode | `omm setup opencode` |
+| pi (pi.dev) | `omm setup pi` |
+| Oh my Pi (omp) | `omm setup omp` |
 
 运行 `omm setup` 自动检测并配置所有已安装的工具。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-mermaid",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-mermaid",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-mermaid",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Architecture mirror for vibe coding — CLI + Claude Code skills",
   "type": "module",
   "bin": {

--- a/src/__tests__/omp.test.ts
+++ b/src/__tests__/omp.test.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getSkillsSource = vi.fn();
+const hasCommand = vi.fn();
+
+vi.mock('../lib/platforms/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/platforms/utils.js')>('../lib/platforms/utils.js');
+  return {
+    ...actual,
+    getSkillsSource,
+    hasCommand,
+  };
+});
+
+describe('omp platform', () => {
+  const originalCwd = process.cwd();
+  const originalHome = process.env.HOME;
+  let tmpDir: string;
+  let skillsSource: string;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omm-omp-'));
+    skillsSource = fs.mkdtempSync(path.join(os.tmpdir(), 'omm-omp-source-'));
+
+    process.env.HOME = tmpDir;
+    getSkillsSource.mockReturnValue(skillsSource);
+    hasCommand.mockReturnValue(true);
+
+    // Ensure no leftover state between tests
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(skillsSource, { recursive: true, force: true });
+  });
+
+  it('isSetup() returns false when target does not exist', async () => {
+    const { omp } = await import('../lib/platforms/omp.js');
+    expect(omp.isSetup()).toBe(false);
+  });
+
+  it('isSetup() returns true when target exists', async () => {
+    const targetDir = path.join(tmpDir, '.omp', 'agent', 'skills', 'oh-my-mermaid');
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+    fs.symlinkSync(skillsSource, targetDir, 'dir');
+
+    const { omp } = await import('../lib/platforms/omp.js');
+    expect(omp.isSetup()).toBe(true);
+  });
+
+  it('setup() creates symlink when target missing', async () => {
+    const { omp } = await import('../lib/platforms/omp.js');
+
+    await omp.setup();
+
+    const targetDir = path.join(tmpDir, '.omp', 'agent', 'skills', 'oh-my-mermaid');
+    expect(fs.existsSync(targetDir)).toBe(true);
+    expect(fs.statSync(targetDir).isDirectory()).toBe(true);
+  });
+
+  it('setup() recreates copy when target already exists', async () => {
+    const targetDir = path.join(tmpDir, '.omp', 'agent', 'skills', 'oh-my-mermaid');
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+    fs.symlinkSync(skillsSource, targetDir, 'dir');
+
+    // Create a different source with a marker to detect recreation
+    const newSource = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'omm-omp-new-src-'));
+    fs.writeFileSync(path.join(newSource, 'marker.txt'), 'new-content');
+    getSkillsSource.mockReturnValue(newSource);
+
+    const { omp } = await import('../lib/platforms/omp.js');
+    await omp.setup();
+
+    expect(fs.existsSync(targetDir)).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, 'marker.txt'))).toBe(true);
+
+    fs.rmSync(newSource, { recursive: true, force: true });
+  });
+
+  it('teardown() removes target when it exists', async () => {
+    const targetDir = path.join(tmpDir, '.omp', 'agent', 'skills', 'oh-my-mermaid');
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+    fs.symlinkSync(skillsSource, targetDir, 'dir');
+
+    const { omp } = await import('../lib/platforms/omp.js');
+    omp.teardown();
+
+    expect(fs.existsSync(targetDir)).toBe(false);
+  });
+
+  it('teardown() is no-op when target missing', async () => {
+    const targetDir = path.join(tmpDir, '.omp', 'agent', 'skills', 'oh-my-mermaid');
+
+    const { omp } = await import('../lib/platforms/omp.js');
+    // Should not throw
+    omp.teardown();
+
+    expect(fs.existsSync(targetDir)).toBe(false);
+  });
+});

--- a/src/__tests__/opencode.test.ts
+++ b/src/__tests__/opencode.test.ts
@@ -1,0 +1,177 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getSkillsSource = vi.fn();
+const hasCommand = vi.fn();
+
+vi.mock('../lib/platforms/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/platforms/utils.js')>('../lib/platforms/utils.js');
+  return {
+    ...actual,
+    getSkillsSource,
+    hasCommand,
+  };
+});
+
+describe('opencode platform', () => {
+  const originalCwd = process.cwd();
+  const originalHome = process.env.HOME;
+  let tmpDir: string;
+  let skillsSource: string;
+  let stderr: string;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omm-opencode-'));
+    skillsSource = '/tmp/omm-test-skills';
+
+    process.env.HOME = tmpDir;
+    getSkillsSource.mockReturnValue(skillsSource);
+    hasCommand.mockReturnValue(true);
+
+    stderr = '';
+    vi.spyOn(process.stderr, 'write').mockImplementation((msg: string | Uint8Array) => {
+      stderr += msg;
+      return true;
+    });
+
+    // Ensure no leftover state between tests
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function configPath(): string {
+    return path.join(tmpDir, '.config', 'opencode', 'opencode.json');
+  }
+
+  it('isSetup() returns false when config file missing', async () => {
+    const { opencode } = await import('../lib/platforms/opencode.js');
+    expect(opencode.isSetup()).toBe(false);
+  });
+
+  it('isSetup() returns false when skills.paths does not include source', async () => {
+    const cfg = path.join(tmpDir, '.config', 'opencode');
+    fs.mkdirSync(cfg, { recursive: true });
+    fs.writeFileSync(path.join(cfg, 'opencode.json'), JSON.stringify({ skills: { paths: ['/other'] } }));
+
+    const { opencode } = await import('../lib/platforms/opencode.js');
+    expect(opencode.isSetup()).toBe(false);
+  });
+
+  it('isSetup() returns true when skills.paths includes source', async () => {
+    const cfg = path.join(tmpDir, '.config', 'opencode');
+    fs.mkdirSync(cfg, { recursive: true });
+    fs.writeFileSync(path.join(cfg, 'opencode.json'), JSON.stringify({ skills: { paths: [skillsSource] } }));
+
+    const { opencode } = await import('../lib/platforms/opencode.js');
+    expect(opencode.isSetup()).toBe(true);
+  });
+
+  it('setup() creates config + adds skills path when file missing', async () => {
+    const { opencode } = await import('../lib/platforms/opencode.js');
+
+    await opencode.setup();
+
+    const cfg = configPath();
+    expect(fs.existsSync(cfg)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(cfg, 'utf-8'));
+    expect(content.skills.paths).toContain(skillsSource);
+  });
+
+  it('setup() appends skills path to existing config', async () => {
+    const cfg = path.join(tmpDir, '.config', 'opencode');
+    fs.mkdirSync(cfg, { recursive: true });
+    fs.writeFileSync(path.join(cfg, 'opencode.json'), JSON.stringify({ skills: { paths: ['/other'] } }));
+
+    const { opencode } = await import('../lib/platforms/opencode.js');
+    await opencode.setup();
+
+    const content = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(content.skills.paths).toContain(skillsSource);
+    expect(content.skills.paths).toContain('/other');
+  });
+
+  it('setup() does NOT duplicate path if already present', async () => {
+    const cfg = path.join(tmpDir, '.config', 'opencode');
+    fs.mkdirSync(cfg, { recursive: true });
+    fs.writeFileSync(path.join(cfg, 'opencode.json'), JSON.stringify({ skills: { paths: [skillsSource] } }));
+
+    const { opencode } = await import('../lib/platforms/opencode.js');
+    await opencode.setup();
+
+    const content = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(content.skills.paths.filter((p: unknown) => p === skillsSource).length).toBe(1);
+    expect(stderr).toContain('already registered');
+  });
+
+  it('setup() parses config with trailing commas successfully', async () => {
+    const cfg = path.join(tmpDir, '.config', 'opencode');
+    fs.mkdirSync(cfg, { recursive: true });
+    // Trailing comma after array
+    fs.writeFileSync(path.join(cfg, 'opencode.json'), '{"skills": {"paths": ["/other",]}}');
+
+    const { opencode } = await import('../lib/platforms/opencode.js');
+    await opencode.setup();
+
+    const content = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(content.skills.paths).toContain('/other');
+    expect(content.skills.paths).toContain(skillsSource);
+  });
+
+  it('setup() does NOT overwrite config with comments (refuses, logs error)', async () => {
+    const cfg = path.join(tmpDir, '.config', 'opencode');
+    fs.mkdirSync(cfg, { recursive: true });
+    const originalContent = `{\n  // comment\n  "skills": { "paths": ["/other"] }\n}`;
+    fs.writeFileSync(path.join(cfg, 'opencode.json'), originalContent);
+
+    const { opencode } = await import('../lib/platforms/opencode.js');
+    await opencode.setup();
+
+    const content = fs.readFileSync(configPath(), 'utf-8');
+    expect(content).toBe(originalContent);
+    expect(stderr).toContain('Could not parse existing config');
+  });
+
+  it('teardown() removes path from config', async () => {
+    const cfg = path.join(tmpDir, '.config', 'opencode');
+    fs.mkdirSync(cfg, { recursive: true });
+    fs.writeFileSync(path.join(cfg, 'opencode.json'), JSON.stringify({ skills: { paths: [skillsSource, '/other'] } }));
+
+    const { opencode } = await import('../lib/platforms/opencode.js');
+    opencode.teardown();
+
+    const content = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(content.skills.paths).not.toContain(skillsSource);
+    expect(content.skills.paths).toContain('/other');
+  });
+
+  it('teardown() deletes skills section when paths become empty', async () => {
+    const cfg = path.join(tmpDir, '.config', 'opencode');
+    fs.mkdirSync(cfg, { recursive: true });
+    fs.writeFileSync(path.join(cfg, 'opencode.json'), JSON.stringify({ skills: { paths: [skillsSource] } }));
+
+    const { opencode } = await import('../lib/platforms/opencode.js');
+    opencode.teardown();
+
+    const content = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(content.skills).toBeUndefined();
+  });
+
+  it('teardown() warns when config exists but is unreadable', async () => {
+    const cfg = path.join(tmpDir, '.config', 'opencode');
+    fs.mkdirSync(cfg, { recursive: true });
+    fs.writeFileSync(path.join(cfg, 'opencode.json'), 'broken json {');
+
+    const { opencode } = await import('../lib/platforms/opencode.js');
+    opencode.teardown();
+
+    expect(stderr).toContain('Skipping teardown');
+  });
+});

--- a/src/__tests__/pi.test.ts
+++ b/src/__tests__/pi.test.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getSkillsSource = vi.fn();
+const hasCommand = vi.fn();
+
+vi.mock('../lib/platforms/utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/platforms/utils.js')>('../lib/platforms/utils.js');
+  return {
+    ...actual,
+    getSkillsSource,
+    hasCommand,
+  };
+});
+
+describe('pi platform', () => {
+  const originalCwd = process.cwd();
+  const originalHome = process.env.HOME;
+  let tmpDir: string;
+  let skillsSource: string;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omm-pi-'));
+    skillsSource = fs.mkdtempSync(path.join(os.tmpdir(), 'omm-pi-source-'));
+
+    process.env.HOME = tmpDir;
+    getSkillsSource.mockReturnValue(skillsSource);
+    hasCommand.mockReturnValue(true);
+
+    // Ensure no leftover state between tests
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(skillsSource, { recursive: true, force: true });
+  });
+
+  it('isSetup() returns false when target does not exist', async () => {
+    const { pi } = await import('../lib/platforms/pi.js');
+    expect(pi.isSetup()).toBe(false);
+  });
+
+  it('isSetup() returns true when target exists', async () => {
+    const targetDir = path.join(tmpDir, '.pi', 'agent', 'skills', 'oh-my-mermaid');
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+    fs.symlinkSync(skillsSource, targetDir, 'dir');
+
+    const { pi } = await import('../lib/platforms/pi.js');
+    expect(pi.isSetup()).toBe(true);
+  });
+
+  it('setup() creates symlink when target missing', async () => {
+    const { pi } = await import('../lib/platforms/pi.js');
+
+    await pi.setup();
+
+    const targetDir = path.join(tmpDir, '.pi', 'agent', 'skills', 'oh-my-mermaid');
+    expect(fs.existsSync(targetDir)).toBe(true);
+    expect(fs.statSync(targetDir).isDirectory()).toBe(true);
+  });
+
+  it('setup() recreates copy when target already exists', async () => {
+    const targetDir = path.join(tmpDir, '.pi', 'agent', 'skills', 'oh-my-mermaid');
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+    fs.symlinkSync(skillsSource, targetDir, 'dir');
+
+    // Create a different source with a marker to detect recreation
+    const newSource = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'omm-pi-new-src-'));
+    fs.writeFileSync(path.join(newSource, 'marker.txt'), 'new-content');
+    getSkillsSource.mockReturnValue(newSource);
+
+    const { pi } = await import('../lib/platforms/pi.js');
+    await pi.setup();
+
+    expect(fs.existsSync(targetDir)).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, 'marker.txt'))).toBe(true);
+
+    fs.rmSync(newSource, { recursive: true, force: true });
+  });
+
+  it('teardown() removes target when it exists', async () => {
+    const targetDir = path.join(tmpDir, '.pi', 'agent', 'skills', 'oh-my-mermaid');
+    fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+    fs.symlinkSync(skillsSource, targetDir, 'dir');
+
+    const { pi } = await import('../lib/platforms/pi.js');
+    pi.teardown();
+
+    expect(fs.existsSync(targetDir)).toBe(false);
+  });
+
+  it('teardown() is no-op when target missing', async () => {
+    const targetDir = path.join(tmpDir, '.pi', 'agent', 'skills', 'oh-my-mermaid');
+
+    const { pi } = await import('../lib/platforms/pi.js');
+    // Should not throw
+    pi.teardown();
+
+    expect(fs.existsSync(targetDir)).toBe(false);
+  });
+});

--- a/src/lib/platforms/index.ts
+++ b/src/lib/platforms/index.ts
@@ -4,10 +4,13 @@ import { codex } from './codex.js';
 import { cursor } from './cursor.js';
 import { openclaw } from './openclaw.js';
 import { antigravity } from './antigravity.js';
+import { opencode } from './opencode.js';
+import { pi } from './pi.js';
+import { omp } from './omp.js';
 
 export type { Platform };
 
-export const ALL_PLATFORMS: Platform[] = [claude, codex, cursor, openclaw, antigravity];
+export const ALL_PLATFORMS: Platform[] = [claude, codex, cursor, openclaw, antigravity, opencode, pi, omp];
 
 export function getPlatformById(id: string): Platform | undefined {
   return ALL_PLATFORMS.find(p => p.id === id);

--- a/src/lib/platforms/omp.ts
+++ b/src/lib/platforms/omp.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { Platform } from './types.js';
+import { getSkillsSource, hasCommand } from './utils.js';
+
+const SKILLS_TARGET = path.join(os.homedir(), '.omp', 'agent', 'skills', 'oh-my-mermaid');
+
+function copyDirSync(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirSync(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+export const omp: Platform = {
+  name: 'Oh my Pi (omp)',
+  id: 'omp',
+
+  detect(): boolean {
+    return hasCommand('omp');
+  },
+
+  isSetup(): boolean {
+    return fs.existsSync(SKILLS_TARGET);
+  },
+
+  async setup(): Promise<void> {
+    const source = getSkillsSource();
+    if (!source) {
+      process.stderr.write('  Could not locate skills directory.\n');
+      return;
+    }
+
+    fs.mkdirSync(path.dirname(SKILLS_TARGET), { recursive: true });
+
+    if (fs.existsSync(SKILLS_TARGET)) {
+      fs.rmSync(SKILLS_TARGET, { recursive: true });
+    }
+    copyDirSync(source, SKILLS_TARGET);
+    process.stderr.write(`  Copied skills → ${SKILLS_TARGET}\n`);
+  },
+
+  teardown(): void {
+    if (fs.existsSync(SKILLS_TARGET)) {
+      fs.rmSync(SKILLS_TARGET, { recursive: true });
+    }
+  },
+};

--- a/src/lib/platforms/opencode.ts
+++ b/src/lib/platforms/opencode.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { Platform } from './types.js';
+import { getSkillsSource, hasCommand } from './utils.js';
+
+const CONFIG_PATH = path.join(os.homedir(), '.config', 'opencode', 'opencode.json');
+
+function readConfig(): Record<string, unknown> | null {
+  if (!fs.existsSync(CONFIG_PATH)) return null;
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf-8');
+    // opencode config may have trailing commas from JSONC origin - strip them
+    const cleaned = raw.replace(/,\s*}/g, '}').replace(/,\s*\]/g, ']');
+    return JSON.parse(cleaned);
+  } catch {
+    return null;
+  }
+}
+
+function writeConfig(config: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + '\n');
+}
+
+function getSkillsPaths(config: Record<string, unknown>): string[] {
+  const skills = config.skills as Record<string, unknown> | undefined;
+  if (!skills || !Array.isArray(skills.paths)) return [];
+  return (skills.paths as unknown[]).filter((p): p is string => typeof p === 'string');
+}
+
+function setSkillsPaths(config: Record<string, unknown>, paths: string[]): void {
+  const skills = (config.skills as Record<string, unknown>) ?? {};
+  skills.paths = paths;
+  config.skills = skills;
+}
+
+export const opencode: Platform = {
+  name: 'OpenCode',
+  id: 'opencode',
+
+  detect(): boolean {
+    return hasCommand('opencode');
+  },
+
+  isSetup(): boolean {
+    const config = readConfig();
+    if (!config) return false;
+    const source = getSkillsSource();
+    if (!source) return false;
+    return getSkillsPaths(config).includes(source);
+  },
+
+  async setup(): Promise<void> {
+    const source = getSkillsSource();
+    if (!source) {
+      process.stderr.write('  Could not locate skills directory.\n');
+      return;
+    }
+
+    let config = readConfig();
+    if (!config) {
+      if (fs.existsSync(CONFIG_PATH)) {
+        process.stderr.write(`  Could not parse existing config at ${CONFIG_PATH}. Please back it up, remove it, and retry.\n`);
+        return;
+      }
+      // Create minimal config
+      config = { $schema: 'https://opencode.ai/config.json' };
+    }
+
+    const paths = getSkillsPaths(config);
+    if (!paths.includes(source)) {
+      paths.push(source);
+      setSkillsPaths(config, paths);
+      writeConfig(config);
+      process.stderr.write(`  Added skills path → ${CONFIG_PATH}\n`);
+    } else {
+      process.stderr.write(`  Skills path already registered.\n`);
+    }
+  },
+
+  teardown(): void {
+    const config = readConfig();
+    if (!config) {
+      if (fs.existsSync(CONFIG_PATH)) {
+        process.stderr.write(`  Could not parse existing config at ${CONFIG_PATH}. Skipping teardown.\n`);
+      }
+      return;
+    }
+
+    const source = getSkillsSource();
+    if (!source) return;
+
+    const paths = getSkillsPaths(config);
+    const filtered = paths.filter(p => p !== source);
+    if (filtered.length !== paths.length) {
+      if (filtered.length === 0) {
+        // Remove empty skills section entirely
+        delete config.skills;
+      } else {
+        setSkillsPaths(config, filtered);
+      }
+      writeConfig(config);
+    }
+  },
+};

--- a/src/lib/platforms/pi.ts
+++ b/src/lib/platforms/pi.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { Platform } from './types.js';
+import { getSkillsSource, hasCommand } from './utils.js';
+
+const SKILLS_TARGET = path.join(os.homedir(), '.pi', 'agent', 'skills', 'oh-my-mermaid');
+
+function copyDirSync(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirSync(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+export const pi: Platform = {
+  name: 'pi (pi.dev)',
+  id: 'pi',
+
+  detect(): boolean {
+    return hasCommand('pi');
+  },
+
+  isSetup(): boolean {
+    return fs.existsSync(SKILLS_TARGET);
+  },
+
+  async setup(): Promise<void> {
+    const source = getSkillsSource();
+    if (!source) {
+      process.stderr.write('  Could not locate skills directory.\n');
+      return;
+    }
+
+    fs.mkdirSync(path.dirname(SKILLS_TARGET), { recursive: true });
+
+    if (fs.existsSync(SKILLS_TARGET)) {
+      fs.rmSync(SKILLS_TARGET, { recursive: true });
+    }
+    copyDirSync(source, SKILLS_TARGET);
+    process.stderr.write(`  Copied skills → ${SKILLS_TARGET}\n`);
+  },
+
+  teardown(): void {
+    if (fs.existsSync(SKILLS_TARGET)) {
+      fs.rmSync(SKILLS_TARGET, { recursive: true });
+    }
+  },
+};

--- a/src/server/viewer.html
+++ b/src/server/viewer.html
@@ -80,6 +80,7 @@ body { font-family: var(--font); background: var(--bg); color: var(--text); disp
 /* Floating controls */
 .float-controls {
   position: absolute; top: 12px; right: 12px;
+  transition: right .22s cubic-bezier(.4,0,.2,1);
   display: flex; align-items: center; gap: 3px;
   z-index: 100;
   background: rgba(0,0,0,0.7);
@@ -91,6 +92,8 @@ body { font-family: var(--font); background: var(--bg); color: var(--text); disp
 .hbtn { background: none; border: 1px solid var(--border-hi); color: var(--text-mid); height: 26px; min-width: 26px; padding: 0 8px; border-radius: 5px; cursor: pointer; font-size: 13px; font-family: var(--font); transition: border-color .12s, color .12s; }
 .hbtn:hover { border-color: #3a3a3a; color: var(--text); }
 #zoom-label { font-size: 11px; color: var(--text-dim); width: 38px; text-align: center; font-family: var(--mono); }
+.float-controls.sidebar-open { right: calc(var(--sidebar-w) + 12px); }
+@media (max-width: 768px) { .float-controls.sidebar-open { right: 12px; } }
 
 #canvas-wrap {
   flex: 1; position: relative; overflow: hidden; cursor: grab; margin-left: 200px;
@@ -842,6 +845,7 @@ function applyTransform() {
 }
 
 function zoomTo(newScale, originX, originY) {
+  if (_raf) { cancelAnimationFrame(_raf); _raf = null; }
   const s = Math.max(MIN_SCALE, Math.min(MAX_SCALE, newScale));
   const cW = canvasWrap.clientWidth, cH = canvasWrap.clientHeight;
   const cx = originX ?? cW/2, cy = originY ?? cH/2;
@@ -853,6 +857,7 @@ function zoomTo(newScale, originX, originY) {
 
 function centerView() {
   if (!svgW) return;
+  if (_raf) { cancelAnimationFrame(_raf); _raf = null; }
   const cW=canvasWrap.clientWidth, cH=canvasWrap.clientHeight;
   const s = Math.min(0.9, (cW-80)/svgW, (cH-80)/svgH);
   vpScale = s;
@@ -898,16 +903,25 @@ function focusGroup(cls) {
     ancestor = ancestor.parentElement;
   }
 
-  // Use the group's border rect for accurate dimensions
-  const border = el.querySelector(':scope > .grp-border') || el;
-  const rect = border.getBoundingClientRect();
-  const wrapRect = canvasWrap.getBoundingClientRect();
+  // Get group's SVG-space position directly from its transform attribute.
+  // Traverse up to root SVG to accumulate nested translates/scales.
+  function getSvgPoint(el) {
+    const rect = el.getBoundingClientRect();
+    const wrapRect = canvasWrap.getBoundingClientRect();
+    // Screen position of element center, relative to canvas-wrap top-left
+    const sx = rect.left + rect.width / 2 - wrapRect.left;
+    const sy = rect.top + rect.height / 2 - wrapRect.top;
+    // Convert to canvas SVG space (reverse pan+zoom transform)
+    const svgX = (sx - vpX) / vpScale;
+    const svgY = (sy - vpY) / vpScale;
+    // Get element dimensions in SVG space
+    const w = rect.width / vpScale;
+    const h = rect.height / vpScale;
+    return { svgX, svgY, w, h };
+  }
 
-  // Convert screen coords to SVG space
-  const svgCenterX = (rect.left + rect.width/2 - wrapRect.left - vpX) / vpScale;
-  const svgCenterY = (rect.top + rect.height/2 - wrapRect.top - vpY) / vpScale;
-  const svgW = rect.width / vpScale;
-  const svgH = rect.height / vpScale;
+  const border = el.querySelector(':scope > .grp-border') || el;
+  const { svgX, svgY, w, h } = getSvgPoint(border);
 
   // Available viewport (account for sidebar: right panel on desktop, bottom drawer on mobile)
   const isMobile = window.innerWidth <= 768;
@@ -917,15 +931,16 @@ function focusGroup(cls) {
   const availH = canvasWrap.clientHeight - sbH - 60;
 
   // Target scale to fit element with padding
-  const targetScale = Math.min(MAX_SCALE, Math.max(0.15, Math.min(availW / svgW, availH / svgH) * 0.85));
+  const targetScale = Math.min(MAX_SCALE, Math.max(0.15, Math.min(availW / w, availH / h) * 0.85));
 
   // Center in available viewport (account for sidebar/drawer)
   const centerX = (canvasWrap.clientWidth - sbW) / 2;
   const centerY = (canvasWrap.clientHeight - sbH) / 2;
-  const toX = centerX - svgCenterX * targetScale;
-  const toY = centerY - svgCenterY * targetScale;
+  const finalScale = vpScale >= targetScale ? vpScale : targetScale;
 
-  animateTo(toX, toY, targetScale);
+  const toX = centerX - svgX * finalScale;
+  const toY = centerY - svgY * finalScale;
+  animateTo(toX, toY, finalScale);
 }
 
 // ── wheel: Figma-style ─────────────────────────────────────
@@ -957,6 +972,7 @@ canvasWrap.addEventListener('wheel', e => {
 // ── pan: space+drag, middle-mouse, empty-area drag ─────────
 let spaceHeld = false;
 let panning = false, panA = {}, panV = {};
+let dragStarted = false;
 
 function updateCursor() {
   if (panning)      canvasWrap.style.cursor = 'grabbing';
@@ -985,14 +1001,18 @@ window.addEventListener('keyup', e => {
 });
 
 canvasWrap.addEventListener('mousedown', e => {
-  const isMiddle   = e.button === 1;
+  const isMiddle = e.button === 1;
   const isSpaceDrag = e.button === 0 && spaceHeld;
-  const isEmptyDrag = e.button === 0 && !spaceHeld &&
-    !e.target.closest('.grp-node') && !e.target.closest('.reg-node');
+  const isLeftDrag = e.button === 0 && !spaceHeld;
 
-  if (isMiddle || isSpaceDrag || isEmptyDrag) {
-    e.preventDefault();
+  if (isMiddle || isSpaceDrag || isLeftDrag) {
+    // Only prevent default for middle-click/space-drag;
+    // left-click must NOT preventDefault so browser can dispatch dblclick.
+    if (isMiddle || isSpaceDrag) e.preventDefault();
     panning = true;
+    // Middle-click and space-drag pan immediately; left-drag waits for threshold
+    dragStarted = isMiddle || isSpaceDrag;
+    window.__ommDidPan = false;
     panA = { x: e.clientX, y: e.clientY };
     panV = { x: vpX, y: vpY };
     updateCursor();
@@ -1001,13 +1021,23 @@ canvasWrap.addEventListener('mousedown', e => {
 
 window.addEventListener('mousemove', e => {
   if (!panning) return;
-  vpX = panV.x + (e.clientX - panA.x);
-  vpY = panV.y + (e.clientY - panA.y);
-  applyTransform();
+  if (!dragStarted) {
+    const dx = Math.abs(e.clientX - panA.x);
+    const dy = Math.abs(e.clientY - panA.y);
+    if (dx > 8 || dy > 8) { dragStarted = true; window.__ommDidPan = true; }
+  }
+  if (dragStarted) {
+    vpX = panV.x + (e.clientX - panA.x);
+    vpY = panV.y + (e.clientY - panA.y);
+    applyTransform();
+  }
 });
 
 window.addEventListener('mouseup', () => {
   if (panning) { panning = false; updateCursor(); }
+  if (window.__ommDidPan) {
+    setTimeout(() => { window.__ommDidPan = false; }, 0);
+  }
 });
 
 // Touch: pan + pinch zoom
@@ -1047,7 +1077,22 @@ window.addEventListener('mouseup', () => {
 
 // close sidebar when clicking empty canvas area
 canvasWrap.addEventListener('click', e => {
+  if (window.__ommDidPan) {
+    e.stopImmediatePropagation();
+    return;
+  }
   if (!e.target.closest('[onclick]')) closeSidebar();
+}, true);
+
+// double-click: zoom to focused group (node), reset on empty area
+canvasWrap.addEventListener('dblclick', e => {
+  const node = e.target.closest('.grp-node');
+  if (node) {
+    const cls = node.dataset.cls;
+    if (cls) focusGroup(cls);
+  } else {
+    centerView();
+  }
 });
 
 // ── sidebar ───────────────────────────────────────────────
@@ -1080,6 +1125,8 @@ window.__openSb = function(cls) {
   }
 };
 
+const floatControls = document.querySelector('.float-controls');
+
 function openSidebar(cls) {
   const data=classesData[cls]||{}, refs=refsData[cls]||{};
   sbTitle.textContent=fmtLabel(cls);
@@ -1105,12 +1152,24 @@ function openSidebar(cls) {
     ].join('');
     html+=`<div class="sb-sec"><div class="sb-sec-title">References</div><div class="sb-refs">${links}</div></div>`;
   }
+
+  // Cross-perspective links: show which perspectives contain this element
+  var _shortName = cls.includes('/') ? cls.split('/').pop() : cls;
+  var _parents = (parentMap[cls] || parentMap[_shortName]) || [];
+  if (_parents.length > 0) {
+    var _pLinks = _parents.map(function(p) {
+      return `<span class="sb-ref" onclick="window.__openSb('${esc(p)}/${esc(_shortName)}')">${esc(fmtLabel(p))} / ${esc(fmtLabel(_shortName))}</span>`;
+    }).join('');
+    html += `<div class="sb-sec"><div class="sb-sec-title">In</div><div class="sb-refs">${_pLinks}</div></div>`;
+  }
   sbFields.innerHTML=html;
   sidebar.classList.add('open');
+  if (floatControls) floatControls.classList.add('sidebar-open');
 }
 
 function closeSidebar() {
   sidebar.classList.remove('open');
+  if (floatControls) floatControls.classList.remove('sidebar-open');
   document.querySelectorAll('.grp-node,.reg-node').forEach(el=>el.classList.remove('selected'));
   document.querySelectorAll('#canvas [data-cls].focus-exempt').forEach(el => el.classList.remove('focus-exempt'));
   selectedCls=null;
@@ -1434,6 +1493,7 @@ function addNavItem(name, prefix, isLast, displayLabel) {
 
 // ── nested element support ────────────────────────────────
 var childrenByPerspective = {};
+var parentMap = {};
 var originalPerspectives = []; // top-level only, before short names pollute classes
 
 async function loadNodeData(perspective, childName) {
@@ -1493,6 +1553,14 @@ async function init() {
     refsData[c]=ra[i];
     childrenByPerspective[c]=(na[i]&&na[i].children)||[];
   });
+
+  // Build reverse map: child -> [parent perspectives] for cross-linking -- uses module-scoped parentMap
+  for (var persp of Object.keys(childrenByPerspective)) {
+    for (var child of childrenByPerspective[persp]) {
+      if (!parentMap[child]) parentMap[child] = [];
+      parentMap[child].push(persp);
+    }
+  }
 
   // Pre-load nested element data for all children
   var nodeLoads = [];


### PR DESCRIPTION
<html><head></head><body>
<p>This PR ships two related feature sets.</p>
<hr>
<h3>1. New Platform Integrations (<code>feat(platforms)</code>)</h3>
<p>Adds support for three new AI coding tools:</p>

Platform | Setup command
-- | --
OpenCode | omm setup opencode
pi (pi.dev) | omm setup pi
Oh My Pi (omp) | omm setup omp


<p><strong>Highlights:</strong></p>
<ul>
<li><strong>OpenCode</strong> uses a JSON config-based approach (<code>~/.config/opencode/opencode.json</code>) with safe read/write: validates array elements, strips trailing commas, and refuses to clobber configs that contain comments or other non-JSON content.</li>
<li><strong>pi / omp</strong> use recursive directory copies for skill installation (avoiding symlink quirks on various OS/FS combinations).</li>
<li><strong>Test coverage</strong> for all three platforms: <code>pi.test.ts</code>, <code>omp.test.ts</code>, <code>opencode.test.ts</code> — covering setup, teardown, idempotent installs, config parsing edge cases, and unreadable-config guards.</li>
<li><strong>Version bumped to 0.3.0</strong> across <code>package.json</code>, <code>package-lock.json</code>, <code>.claude-plugin/plugin.json</code>, and <code>.claude-plugin/marketplace.json</code>.</li>
<li><strong>READMEs updated</strong> (EN, KO, JA, ZH, TR) with new platform table rows.</li>
</ul>
<hr>
<h3>2. Interactive Viewer Improvements (<code>feat(viewer)</code>)</h3>
<p>Makes the <code>omm view</code> browser canvas significantly more usable.</p>
<p><strong>Pan &amp; Zoom</strong></p>
<ul>
<li>Pan from anywhere — left-drag works even when clicking directly on a node. An 8-pixel drag threshold distinguishes intentional pans from normal clicks.</li>
<li>No more accidental auto-unzoom — clicking a box preserves your current zoom level if you're already zoomed in further than the fit scale.</li>
<li>Reliable reset — <code>centerView()</code> and <code>zoomTo()</code> now cancel stale RAF animations, so the "fit" button and double-click reset always work even mid-animation.</li>
<li>Correct coordinate transform — fixed <code>getSvgPoint</code> to reverse the pan offset (<code>vpX</code>/<code>vpY</code>), eliminating the "jump to left corner" bug when focusing a previously-panned group.</li>
</ul>
<p><strong>Navigation</strong></p>
<ul>
<li>Double-click to zoom/reset — double-click a node to zoom in on it; double-click empty canvas background to reset to overview.</li>
<li>Cross-perspective links — the sidebar now shows an <strong>"In"</strong> section linking to the parent perspective(s) where an element is defined (e.g. clicking <code>agent-kernel</code> inside <code>rest-api</code> lets you jump directly to <code>overall-architecture/agent-kernel</code>).</li>
</ul>
<p><strong>UI Polish</strong></p>
<ul>
<li>Floating zoom/fit/theme controls slide left when the sidebar opens, so they remain accessible without closing the panel. Mobile view retains right-aligned placement since the sidebar is a bottom drawer.</li>
</ul></body></html>